### PR TITLE
fix: use fs promises for migrations

### DIFF
--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,7 +1,7 @@
 import { Kysely, PostgresDialect, Migrator, FileMigrationProvider } from "kysely";
 import { Pool } from "pg";
-import * as path from "path";
-import * as fs from "fs";
+import path from "path";
+import { promises as fs } from "fs";
 
 async function migrate() {
   const db = new Kysely<any>({


### PR DESCRIPTION
## Summary
- use fs/promises in Kysely FileMigrationProvider to satisfy types

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c1e855c7208323a8e5e6a8e31e4c73