### PR TITLE
Auto run migrations on startup if DB is empty

### DIFF
--- a/src/app/api/auth/[...auth]/route.ts
+++ b/src/app/api/auth/[...auth]/route.ts
@@ -1,13 +1,27 @@
 import { betterAuth } from "better-auth";
 import { nextCookies, toNextJsHandler } from "better-auth/next-js";
-import { Kysely, PostgresDialect } from "kysely";
+import { Kysely, PostgresDialect, sql } from "kysely";
 import { Pool } from "pg";
+import { migrateToLatest } from "@/db/migrate";
 
 const db = new Kysely({
   dialect: new PostgresDialect({
     pool: new Pool({ connectionString: process.env.DATABASE_URL })
   })
 });
+
+async function ensureMigrated() {
+  const { rows } = await sql<{
+    exists: string | null;
+  }>`select to_regclass('public.users') as exists`.execute(db);
+  if (!rows[0]?.exists) {
+    await migrateToLatest();
+  }
+}
+
+if (process.env.NEXT_PHASE !== "phase-production-build") {
+  await ensureMigrated();
+}
 
 const auth = betterAuth({
   database: { db, type: "postgres" },

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -2,8 +2,9 @@ import { Kysely, PostgresDialect, Migrator, FileMigrationProvider } from "kysely
 import { Pool } from "pg";
 import path from "path";
 import { promises as fs } from "fs";
+import { fileURLToPath } from "url";
 
-async function migrate() {
+export async function migrateToLatest() {
   const db = new Kysely<any>({
     dialect: new PostgresDialect({
       pool: new Pool({ connectionString: process.env.DATABASE_URL })
@@ -37,4 +38,6 @@ async function migrate() {
   await db.destroy();
 }
 
-migrate();
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  migrateToLatest();
+}


### PR DESCRIPTION
## Summary
- Run migrations programmatically at startup when `users` table is missing
- Export migration helper usable from runtime and CLI

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2ffb77d188323b31385b3c10e3618