### PR TITLE
Fix migration path for production build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  outputFileTracingIncludes: {
+    "/api/auth/[...auth]": ["src/db/migrations/*"],
+  },
 };
 
 export default nextConfig;

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -16,7 +16,7 @@ export async function migrateToLatest() {
     provider: new FileMigrationProvider({
       fs,
       path,
-      migrationFolder: path.join(__dirname, "migrations")
+      migrationFolder: path.join(process.cwd(), "src", "db", "migrations")
     })
   });
 

--- a/src/db/migrations/001_init.js
+++ b/src/db/migrations/001_init.js
@@ -1,7 +1,9 @@
-import type { Kysely } from "kysely";
 import { sql } from "kysely";
 
-export async function up(db: Kysely<any>): Promise<void> {
+/**
+ * @param {import('kysely').Kysely<any>} db
+ */
+export async function up(db) {
   await db.schema
     .createTable("users")
     .addColumn("id", "text", (col) => col.primaryKey())
@@ -57,9 +59,12 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn("counter", "bigint", (col) => col.notNull().defaultTo(0))
     .addColumn("transports", "text")
     .execute();
-}
+  }
 
-export async function down(db: Kysely<any>): Promise<void> {
+/**
+ * @param {import('kysely').Kysely<any>} db
+ */
+export async function down(db) {
   await db.schema.dropTable("authenticators").execute();
   await db.schema.dropTable("verification_tokens").execute();
   await db.schema.dropTable("user_keys").execute();


### PR DESCRIPTION
## Summary
- ensure migrations are packaged by Next.js build
- load migrations from project root at runtime
- convert initial migration to plain JavaScript

## Testing
- `npm test` *(fails: Missing script: "test")*
- `BETTER_AUTH_SECRET=secret npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c42ffd9c8c8323a38f48840ef55966