### PR TITLE
Center main content horizontally

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
         </div>
         <ThemeProvider>
           <Header />
-          <main className="container flex-1 py-10 sm:py-12 lg:py-16">{children}</main>
+          <main className="flex-1 self-center w-full max-w-7xl px-4 sm:px-6 lg:px-8 py-10 sm:py-12 lg:py-16">{children}</main>
           <footer className="border-t py-8 text-sm text-neutral-600 dark:text-neutral-400">
             <div className="container flex flex-col items-center justify-between gap-4 sm:flex-row">
               <div className="flex items-center gap-2">


### PR DESCRIPTION
Horizontally center the `<main>` element by applying `self-center` and width constraints directly to it, replacing the ineffective `container` class.

---
<a href="https://cursor.com/background-agent?bcId=bc-8333d7ce-6e87-4f49-97d0-6d22fa15205f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8333d7ce-6e87-4f49-97d0-6d22fa15205f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

