### PR TITLE
Fix project fetch and document roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS
+
+## Code style
+- Keep React and Next.js components concise and prefer utility functions over repeating logic.
+- Surface meaningful fallbacks instead of throwing unhandled errors in server components and API routes.
+
+## Testing
+- After changing application code or documentation, run `npm run build` to ensure the project still compiles.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,27 @@ docker compose up --build
 ```
 
 The web application will be available at `http://localhost:3000` and PostgreSQL will listen on port `5432`.
+
+## Platform Overview
+
+extractPDF is evolving into a single workspace for running large batches of PDF and image analyses with the help of LLMs. Each project represents a collection of files plus the automation rules that dictate how those files are interpreted. Users pick the file type (PDF or image) when creating a project and then select the instruction set that best matches their goal.
+
+## Available Instruction Sets
+
+Projects can be configured with one of several predefined instruction bundles, with support for custom prompts when a bespoke workflow is required:
+
+- **OCR all text** – capture every piece of text on each page.
+- **Full page breakdown** – return all textual and visual information that appears on a page.
+- **Extract filled fields** – produce structured JSON with the values discovered in predefined form fields.
+- **Signature detection** – flag whether a page appears to contain a signature.
+- **Custom prompt** – let the user define their own LLM instructions.
+
+The execution strategy can vary per task. Some flows will run a prompt per page and aggregate the raw responses into a JSON array, while others may trigger a follow-up LLM call to combine page-level insights into a single structured payload.
+
+## Adaptive Project Interfaces
+
+The user interface changes based on the chosen instruction set. For example, projects that extract filled fields expose configuration inputs for each field name and type so downstream JSON objects are well defined. Other project types can reveal views suited to visual inspection, OCR review, or signature confirmation.
+
+## File Intake and API Access
+
+Every project can accept files uploaded directly in the application and, when enabled through the project configuration, through an API endpoint. Files are currently persisted on the server, though alternative storage backends may be introduced later.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -1,14 +1,37 @@
 import Link from "next/link";
+import { headers } from "next/headers";
 
-async function fetchProject(id: string) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ""}/api/projects/${id}`, { cache: "no-store" });
-  if (!res.ok) return null;
-  return res.json();
+function resolveBaseUrl() {
+  if (process.env.NEXT_PUBLIC_BASE_URL) {
+    return process.env.NEXT_PUBLIC_BASE_URL;
+  }
+
+  const headersList = headers();
+  const host = headersList.get("host");
+  if (!host) {
+    return null;
+  }
+
+  const protocol = headersList.get("x-forwarded-proto") ?? "http";
+  return `${protocol}://${host}`;
+}
+
+async function fetchProject(baseUrl: string, id: string) {
+  try {
+    const url = new URL(`/api/projects/${id}`, baseUrl);
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res.ok) return null;
+    return res.json();
+  } catch (error) {
+    console.error(`Failed to fetch project ${id}`, error);
+    return null;
+  }
 }
 
 export default async function ProjectPage({ params }: { params: { id: string } }) {
   const { id } = params;
-  const project = await fetchProject(id);
+  const baseUrl = resolveBaseUrl();
+  const project = baseUrl ? await fetchProject(baseUrl, id) : null;
   return (
     <div className="mx-auto max-w-3xl space-y-8">
       <div className="flex items-center justify-between">

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+A running list of the major capabilities planned for extractPDF.
+
+## Instruction Sets
+- [ ] Provide an instruction set that performs OCR on all text within each file.
+- [ ] Provide an instruction set that returns complete textual and visual page breakdowns.
+- [ ] Provide an instruction set that extracts filled form fields as structured JSON.
+- [ ] Provide an instruction set that detects signatures on uploaded pages.
+- [ ] Allow custom, user-defined prompts for bespoke analyses.
+
+## Processing Flow
+- [ ] Support executing prompts on a per-page basis and aggregating results into JSON arrays.
+- [ ] Support secondary aggregation passes that combine page-level insights via an additional LLM call.
+
+## User Interface
+- [ ] Let project creators choose the file type (PDF or image) and applicable instruction set.
+- [ ] Adapt the project UI to reflect the selected task, including field configuration for extraction workflows.
+
+## Ingestion and Storage
+- [ ] Enable direct uploads of files into a project.
+- [ ] Enable optional API-based ingestion that can be toggled per project.
+- [ ] Revisit file storage so uploads can be stored outside the application server if needed.


### PR DESCRIPTION
## Summary
- resolve the project details fetch to an absolute base URL using request headers so project pages stop crashing on the server
- document the high-level LLM analysis goals, instruction sets, and workflows in the README
- add a living tasks checklist and contributor guidance in AGENTS.md

## Testing
- npm run build *(fails: Next.js cannot download Google Fonts in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c85dfb53588323a7df0717440e9b14