### PR TITLE
Fix header sanitization typing for fetch requests

### DIFF
--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -54,10 +54,15 @@ function extractMessageContent(message: any): string {
   return "";
 }
 
-function sanitizeHeaders(headers: Record<string, string | undefined>) {
-  return Object.fromEntries(
-    Object.entries(headers).filter(([, value]) => typeof value === "string" && value.trim().length > 0)
+function sanitizeHeaders(headers: Record<string, string | undefined>): Record<string, string> {
+  const sanitizedEntries = Object.entries(headers).filter(
+    (entry): entry is [string, string] => {
+      const [, value] = entry;
+      return typeof value === "string" && value.trim().length > 0;
+    }
   );
+
+  return Object.fromEntries(sanitizedEntries);
 }
 
 export class OpenRouterClient implements LanguageModel {


### PR DESCRIPTION
## Summary
- ensure the header sanitization helper returns only string values via a type guard
- keep the fetch call compatible with `HeadersInit` when building OpenRouter requests

## Testing
- npm run build *(fails: Turbopack cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c98ce155dc8323b204d2cf40838651