### PR TITLE
Avoid remote font fetch during Next.js build

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,6 @@ import type { Metadata } from "next";
 import "./globals.css";
 import Header from "@/components/Header";
 import { ThemeProvider } from "@/components/ThemeProvider";
-import { Plus_Jakarta_Sans } from "next/font/google";
-
-const jakarta = Plus_Jakarta_Sans({ subsets: ["latin"], weight: ["400", "500", "600", "700", "800" ] });
 
 export const metadata: Metadata = {
   title: "extractPDF",
@@ -18,7 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={"min-h-dvh bg-white text-gray-900 dark:bg-black dark:text-gray-100 antialiased selection:bg-blue-600/20 selection:text-blue-900 dark:selection:text-blue-100 flex flex-col " + jakarta.className}>
+      <body className="min-h-dvh bg-white text-gray-900 dark:bg-black dark:text-gray-100 antialiased selection:bg-blue-600/20 selection:text-blue-900 dark:selection:text-blue-100 flex flex-col font-sans">
         <div className="pointer-events-none fixed inset-0 -z-10">
           <div className="absolute inset-0 bg-gradient-to-b from-blue-50/80 via-transparent to-transparent dark:from-blue-950/40" />
           <div className="absolute -top-24 left-1/2 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-gradient-to-tr from-blue-200/50 via-purple-200/30 to-pink-200/30 blur-3xl dark:from-blue-900/30 dark:via-purple-900/20 dark:to-pink-900/20" />

--- a/src/lib/page-processing.ts
+++ b/src/lib/page-processing.ts
@@ -181,12 +181,14 @@ function buildPageMessages(params: {
 
   const textContent = page.textContent?.trim().length ? page.textContent : "No text content was provided for this page.";
 
+  const textBlockDelimiter = "```";
+
   const userContentParts = [
     `Document page number: ${page.pageNumber}.`,
     "Extracted text content:",
-    """,
+    textBlockDelimiter,
     textContent,
-    """"
+    textBlockDelimiter
   ];
 
   if (page.images?.length) {
@@ -228,11 +230,12 @@ function buildAggregationMessages<TRecord>(
   }
 
   const serializedRecords = JSON.stringify(options.aggregatedRecords, null, 2);
+  const textBlockDelimiter = "```";
   const userContent = [
     "Here are the page-level records you must combine:",
-    """,
+    textBlockDelimiter,
     serializedRecords,
-    """",
+    textBlockDelimiter,
     "Use the records to fulfill the aggregation request."
   ].join("\n");
 


### PR DESCRIPTION
## Summary
- stop importing the Plus Jakarta Sans Google Font so the build does not need external network access
- replace the triple-quote delimiters in page processing prompts with markdown code fences to keep the TypeScript valid

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c98e6bbc608323a79da4147568c1a2