### PR TITLE
Protect dashboard access and adjust CTA styles

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from "react";
+import { redirect } from "next/navigation";
+import { getCurrentUserId } from "@/lib/auth";
+
+export default async function DashboardLayout({ children }: { children: ReactNode }) {
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    redirect("/login");
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -16,7 +16,8 @@ export default function LoginPage() {
       body: JSON.stringify({ email, password })
     });
     if (res.ok) {
-      router.push("/");
+      router.push("/dashboard");
+      router.refresh();
     } else {
       alert("Failed to sign in");
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
             Transform PDFs into structured knowledge. Upload, analyze, and extract insights with a beautiful, fast, and privacy-first experience.
           </p>
           <div className="flex flex-wrap items-center justify-center gap-4">
-            <Link href="/register" className="btn btn-lg btn-primary">Get started</Link>
+            <Link href="/register" className="btn btn-lg btn-primary text-white">Get started</Link>
             <Link href="/login" className="btn btn-lg btn-secondary">Sign in</Link>
             <Link href="/dashboard" className="btn btn-lg btn-ghost">Dashboard</Link>
           </div>
@@ -130,7 +130,7 @@ export default function Home() {
           <h3 className="text-2xl font-semibold">Start extracting insights today</h3>
           <p className="mt-2 opacity-90">Join in minutes. Your first project is free.</p>
           <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
-            <Link href="/register" className="btn btn-lg bg-white text-blue-700 hover:bg-white/90">Create free account</Link>
+            <Link href="/register" className="btn btn-lg bg-white text-black hover:bg-white/90">Create free account</Link>
             <Link href="/dashboard" className="btn btn-lg border border-white/30 bg-white/10 text-white hover:bg-white/15">Explore dashboard</Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add an authenticated dashboard layout that redirects unauthenticated visitors to the login page
- redirect successful email/password logins straight to the dashboard and refresh client state
- tweak landing page CTA colors so "Get started" renders white text and "Create free account" uses black text

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9927406e88323a517720585f7e599