### PR TITLE
feat: show account in navbar when authenticated

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { getCurrentUserId } from "@/lib/auth";
+import { getDb } from "@/db/client";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const userId = await getCurrentUserId();
+    if (!userId) {
+      return NextResponse.json({ user: null });
+    }
+
+    const db = getDb() as any;
+    const record = await db
+      .selectFrom("user")
+      .select(["id", "name", "email", "image"])
+      .where("id", "=", userId)
+      .executeTakeFirst();
+
+    if (!record) {
+      return NextResponse.json({ user: null });
+    }
+
+    const user = {
+      id: record.id as string,
+      name: (record.name as string | null) ?? null,
+      email: record.email as string,
+      image: (record.image as string | null) ?? null
+    };
+
+    return NextResponse.json({ user });
+  } catch (error) {
+    console.error("Failed to fetch current user", error);
+    return NextResponse.json({ user: null }, { status: 500 });
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,88 @@
 "use client";
+import { useEffect, useState } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useTheme } from "next-themes";
+
+type CurrentUser = {
+  id: string;
+  name: string | null;
+  email: string;
+  image?: string | null;
+};
 
 export default function Header() {
   const pathname = usePathname();
+  const router = useRouter();
   const { theme, setTheme } = useTheme();
+  const [user, setUser] = useState<CurrentUser | null | undefined>(undefined);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadUser() {
+      try {
+        const res = await fetch("/api/auth/me", {
+          method: "GET",
+          credentials: "include",
+          cache: "no-store"
+        });
+
+        if (!active) return;
+
+        if (!res.ok) {
+          setUser(null);
+          return;
+        }
+
+        const data: { user: CurrentUser | null } = await res.json();
+        setUser(data.user ?? null);
+      } catch (error) {
+        if (!active) return;
+        console.error("Failed to load current user", error);
+        setUser(null);
+      }
+    }
+
+    loadUser();
+
+    return () => {
+      active = false;
+    };
+  }, [pathname]);
+
+  const handleSignOut = async () => {
+    try {
+      const res = await fetch("/api/auth/sign-out", {
+        method: "POST",
+        credentials: "include"
+      });
+
+      if (!res.ok) {
+        console.error("Sign out failed", await res.text());
+        alert("Unable to log out right now. Please try again.");
+        return;
+      }
+
+      setUser(null);
+      router.push("/");
+      router.refresh();
+    } catch (error) {
+      console.error("Sign out failed", error);
+      alert("Unable to log out right now. Please try again.");
+    }
+  };
+
+  const onDashboard = pathname?.startsWith("/dashboard") ?? false;
+  const trimmedName = user?.name?.trim();
+  const accountName =
+    trimmedName && trimmedName.length > 0
+      ? trimmedName.split(/\s+/)[0]
+      : user?.email ?? "";
+  const accountLabel = user
+    ? `Account${accountName ? ` (${accountName})` : ""}`
+    : "Dashboard";
+
   return (
     <header className="sticky top-0 z-50 border-b bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:border-neutral-800 dark:bg-black/50 dark:supports-[backdrop-filter]:bg-black/40">
       <div className="container flex items-center justify-between py-5">
@@ -14,9 +91,27 @@ export default function Header() {
           <span className="heading-gradient">ExtractPDF</span>
         </Link>
         <nav className="flex items-center gap-3 text-sm">
-          <Link className={navClass(pathname === "/dashboard")} href="/dashboard">Dashboard</Link>
-          <Link className={navClass(pathname === "/login")} href="/login">Login</Link>
-          <Link className={navClass(pathname === "/register")} href="/register">Register</Link>
+          <Link className={navClass(onDashboard)} href="/dashboard">
+            {accountLabel}
+          </Link>
+          {user === undefined ? null : user ? (
+            <button
+              type="button"
+              onClick={handleSignOut}
+              className={`${navClass(false)} cursor-pointer`}
+            >
+              Log out
+            </button>
+          ) : (
+            <>
+              <Link className={navClass(pathname === "/login")} href="/login">
+                Login
+              </Link>
+              <Link className={navClass(pathname === "/register")} href="/register">
+                Register
+              </Link>
+            </>
+          )}
           <button
             onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
             className="ml-2 inline-flex h-9 w-9 items-center justify-center rounded-full border border-neutral-200 bg-white/70 text-neutral-700 shadow-sm transition hover:bg-white dark:border-neutral-800 dark:bg-black/60 dark:text-neutral-300 dark:hover:bg-black cursor-pointer"


### PR DESCRIPTION
## Summary
- load the authenticated user in the header so the navigation can switch between account details and auth links
- add a client-side sign-out handler that returns to the homepage and refreshes the session
- expose a `/api/auth/me` route to provide the header with current user information

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c999456870832380c50481eeba1aae