### PR TITLE
Add project file ingestion and storage features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/extractpdf
 
 # Secret used by Better Auth for signing tokens
 BETTER_AUTH_SECRET=better-auth-secret-123456789
+
+# Directory for storing uploaded files (optional)
+FILE_STORAGE_ROOT=./uploads

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # misc
 .DS_Store
 *.pem
+uploads/
 
 # debug
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ The user interface changes based on the chosen instruction set. For example, pro
 
 ## File Intake and API Access
 
-Every project can accept files uploaded directly in the application and, when enabled through the project configuration, through an API endpoint. Files are currently persisted on the server, though alternative storage backends may be introduced later.
+Project pages now include a direct upload panel so PDFs and images can be attached without leaving the app. Teams that need system-to-system ingestion can enable an API toggle per project to generate a bearer token and receive files via `POST /api/projects/:id/ingest`. Uploaded binaries are written to the directory defined by the optional `FILE_STORAGE_ROOT` environment variable (defaulting to `./uploads`), allowing deployments to target shared or external storage volumes when desired.

--- a/src/app/api/projects/[id]/files/route.ts
+++ b/src/app/api/projects/[id]/files/route.ts
@@ -1,0 +1,119 @@
+import { generateId } from "better-auth";
+import { NextRequest } from "next/server";
+import { getDb } from "@/db/client";
+import { getCurrentUserId } from "@/lib/auth";
+import { persistProjectFile } from "@/lib/storage";
+
+const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024; // 25 MB per upload
+
+type Params = { params: Promise<{ id: string }> };
+
+type ProjectRow = {
+  id: string;
+  ownerId: string;
+};
+
+type ProjectFileRow = {
+  id: string;
+  originalName: string;
+  size: string | number;
+  contentType: string | null;
+  uploadedViaApi: boolean;
+  createdAt: Date | string;
+};
+
+function normalizeFileRow(row: ProjectFileRow) {
+  return {
+    id: row.id,
+    originalName: row.originalName,
+    size: typeof row.size === "string" ? Number(row.size) : row.size,
+    contentType: row.contentType,
+    uploadedViaApi: row.uploadedViaApi,
+    createdAt:
+      row.createdAt instanceof Date
+        ? row.createdAt.toISOString()
+        : new Date(row.createdAt).toISOString()
+  };
+}
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  const userId = await getCurrentUserId();
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const db = getDb() as any;
+  const project = (await db
+    .selectFrom("project")
+    .select(["id", "ownerId"])
+    .where("id", "=", id)
+    .executeTakeFirst()) as ProjectRow | undefined;
+
+  if (!project || project.ownerId !== userId) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const files = (await db
+    .selectFrom("projectFile")
+    .select(["id", "originalName", "size", "contentType", "uploadedViaApi", "createdAt"])
+    .where("projectId", "=", id)
+    .orderBy("createdAt", "desc")
+    .execute()) as ProjectFileRow[];
+
+  return Response.json(files.map(normalizeFileRow));
+}
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  const userId = await getCurrentUserId();
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const db = getDb() as any;
+  const project = (await db
+    .selectFrom("project")
+    .select(["id", "ownerId"])
+    .where("id", "=", id)
+    .executeTakeFirst()) as ProjectRow | undefined;
+
+  if (!project || project.ownerId !== userId) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const formData = await request.formData();
+  const file = formData.get("file");
+  if (!file || typeof (file as any).arrayBuffer !== "function") {
+    return Response.json({ error: "File is required" }, { status: 400 });
+  }
+
+  const upload = file as File;
+  if (upload.size > MAX_FILE_SIZE_BYTES) {
+    return Response.json({ error: "File exceeds size limit" }, { status: 413 });
+  }
+
+  const { relativePath } = await persistProjectFile(project.id, upload);
+
+  const fileId = generateId();
+  await db
+    .insertInto("projectFile")
+    .values({
+      id: fileId,
+      projectId: project.id,
+      ownerId: userId,
+      originalName: upload.name,
+      storagePath: relativePath,
+      contentType: upload.type || null,
+      size: BigInt(upload.size),
+      uploadedViaApi: false
+    })
+    .executeTakeFirst();
+
+  return Response.json(
+    normalizeFileRow({
+      id: fileId,
+      originalName: upload.name,
+      size: upload.size,
+      contentType: upload.type || null,
+      uploadedViaApi: false,
+      createdAt: new Date()
+    })
+  );
+}

--- a/src/app/api/projects/[id]/ingest/route.ts
+++ b/src/app/api/projects/[id]/ingest/route.ts
@@ -1,0 +1,108 @@
+import { generateId } from "better-auth";
+import { NextRequest } from "next/server";
+import { getDb } from "@/db/client";
+import { persistProjectFile } from "@/lib/storage";
+
+const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024;
+
+type Params = { params: Promise<{ id: string }> };
+
+type ProjectRow = {
+  id: string;
+  ownerId: string;
+  apiIngestionEnabled: boolean;
+  apiToken: string | null;
+};
+
+type ProjectFileRow = {
+  id: string;
+  originalName: string;
+  size: number;
+  contentType: string | null;
+  uploadedViaApi: boolean;
+  createdAt: Date;
+};
+
+function extractToken(request: NextRequest): string | null {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader) {
+    const [scheme, token] = authHeader.split(" ", 2);
+    if (scheme?.toLowerCase() === "bearer" && token) {
+      return token.trim();
+    }
+  }
+  const headerToken = request.headers.get("x-api-token");
+  if (headerToken?.trim()) {
+    return headerToken.trim();
+  }
+  return null;
+}
+
+function normalizeFileRow(row: ProjectFileRow) {
+  return {
+    id: row.id,
+    originalName: row.originalName,
+    size: row.size,
+    contentType: row.contentType,
+    uploadedViaApi: row.uploadedViaApi,
+    createdAt: row.createdAt.toISOString()
+  };
+}
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  const token = extractToken(request);
+  if (!token) {
+    return Response.json({ error: "Missing API token" }, { status: 401 });
+  }
+
+  const db = getDb() as any;
+  const project = (await db
+    .selectFrom("project")
+    .select(["id", "ownerId", "apiIngestionEnabled", "apiToken"])
+    .where("id", "=", id)
+    .executeTakeFirst()) as ProjectRow | undefined;
+
+  if (!project || !project.apiIngestionEnabled || !project.apiToken || project.apiToken !== token) {
+    return Response.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const formData = await request.formData();
+  const file = formData.get("file");
+  if (!file || typeof (file as any).arrayBuffer !== "function") {
+    return Response.json({ error: "File is required" }, { status: 400 });
+  }
+
+  const upload = file as File;
+  if (upload.size > MAX_FILE_SIZE_BYTES) {
+    return Response.json({ error: "File exceeds size limit" }, { status: 413 });
+  }
+
+  const { relativePath } = await persistProjectFile(project.id, upload);
+
+  const fileId = generateId();
+  await db
+    .insertInto("projectFile")
+    .values({
+      id: fileId,
+      projectId: project.id,
+      ownerId: project.ownerId,
+      originalName: upload.name,
+      storagePath: relativePath,
+      contentType: upload.type || null,
+      size: BigInt(upload.size),
+      uploadedViaApi: true
+    })
+    .executeTakeFirst();
+
+  return Response.json(
+    normalizeFileRow({
+      id: fileId,
+      originalName: upload.name,
+      size: upload.size,
+      contentType: upload.type || null,
+      uploadedViaApi: true,
+      createdAt: new Date()
+    })
+  );
+}

--- a/src/app/api/projects/[id]/ingestion/route.ts
+++ b/src/app/api/projects/[id]/ingestion/route.ts
@@ -1,0 +1,75 @@
+import { randomBytes } from "crypto";
+import { sql } from "kysely";
+import { NextRequest } from "next/server";
+import { getDb } from "@/db/client";
+import { getCurrentUserId } from "@/lib/auth";
+
+type Params = { params: Promise<{ id: string }> };
+
+type ProjectRow = {
+  id: string;
+  ownerId: string;
+  apiIngestionEnabled: boolean;
+  apiToken: string | null;
+};
+
+function createToken(): string {
+  return randomBytes(24).toString("hex");
+}
+
+export async function PATCH(request: NextRequest, { params }: Params) {
+  const { id } = await params;
+  const userId = await getCurrentUserId();
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const db = getDb() as any;
+  const project = (await db
+    .selectFrom("project")
+    .select(["id", "ownerId", "apiIngestionEnabled", "apiToken"])
+    .where("id", "=", id)
+    .executeTakeFirst()) as ProjectRow | undefined;
+
+  if (!project || project.ownerId !== userId) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const payload = await request.json().catch(() => ({}));
+  const shouldEnable =
+    typeof payload.apiIngestionEnabled === "boolean"
+      ? payload.apiIngestionEnabled
+      : project.apiIngestionEnabled;
+  const regenerate = payload.regenerateToken === true;
+
+  let token = project.apiToken;
+  const updates: Record<string, unknown> = {};
+
+  if (shouldEnable !== project.apiIngestionEnabled) {
+    updates.apiIngestionEnabled = shouldEnable;
+  }
+
+  if (regenerate || (shouldEnable && !token)) {
+    token = createToken();
+    updates.apiToken = token;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return Response.json({
+      apiIngestionEnabled: project.apiIngestionEnabled,
+      apiToken: project.apiToken
+    });
+  }
+
+  await db
+    .updateTable("project")
+    .set({
+      ...updates,
+      updatedAt: sql`now()`
+    })
+    .where("id", "=", id)
+    .executeTakeFirst();
+
+  return Response.json({
+    apiIngestionEnabled: shouldEnable,
+    apiToken: token
+  });
+}

--- a/src/app/projects/[id]/ProjectFilesPanel.tsx
+++ b/src/app/projects/[id]/ProjectFilesPanel.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type ProjectFile = {
+  id: string;
+  originalName: string;
+  size: number;
+  contentType: string | null;
+  uploadedViaApi: boolean;
+  createdAt: string;
+};
+
+type Props = {
+  projectId: string;
+  initialFiles: ProjectFile[];
+};
+
+function formatBytes(size: number): string {
+  if (!Number.isFinite(size) || size <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const index = Math.min(Math.floor(Math.log(size) / Math.log(1024)), units.length - 1);
+  const value = size / Math.pow(1024, index);
+  return `${value.toFixed(value >= 10 || index === 0 ? 0 : 1)} ${units[index]}`;
+}
+
+function formatTimestamp(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return timestamp;
+  return date.toLocaleString();
+}
+
+export function ProjectFilesPanel({ projectId, initialFiles }: Props) {
+  const [files, setFiles] = useState<ProjectFile[]>(initialFiles);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<"idle" | "uploading">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const hasFiles = useMemo(() => files.length > 0, [files]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedFile || status === "uploading") return;
+
+    setStatus("uploading");
+    setError(null);
+    try {
+      const formData = new FormData();
+      formData.append("file", selectedFile);
+
+      const response = await fetch(`/api/projects/${projectId}/files`, {
+        method: "POST",
+        body: formData
+      });
+
+      const payload = await response.json().catch(() => null);
+      if (!response.ok || !payload) {
+        const message = payload && typeof (payload as any).error === "string" ? (payload as any).error : "Upload failed";
+        throw new Error(message);
+      }
+
+      const uploaded = payload as ProjectFile;
+      setFiles((previous) => [uploaded, ...previous]);
+      setSelectedFile(null);
+      const input = event.currentTarget.elements.namedItem("file") as HTMLInputElement | null;
+      if (input) {
+        input.value = "";
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setStatus("idle");
+    }
+  };
+
+  return (
+    <div className="card space-y-5">
+      <div>
+        <h2 className="text-xl font-semibold">Project files</h2>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+          Upload PDF or image files directly into this project. Files are stored in the configured storage directory so they
+          can be processed later.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-3 rounded-lg border border-dashed border-gray-300 p-4 dark:border-gray-700">
+        <label className="block text-sm font-medium">Upload a file</label>
+        <input
+          type="file"
+          name="file"
+          accept="application/pdf,image/*"
+          onChange={(event) => {
+            const file = event.target.files?.[0] ?? null;
+            setSelectedFile(file);
+            setError(null);
+          }}
+          className="input"
+        />
+        <div className="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
+          {selectedFile ? <span>{selectedFile.name}</span> : <span>No file selected</span>}
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={!selectedFile || status === "uploading"}
+          >
+            {status === "uploading" ? "Uploading..." : "Upload file"}
+          </button>
+        </div>
+        {error ? <p className="text-sm text-red-600">{error}</p> : null}
+      </form>
+
+      <div>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Uploaded files</h3>
+        {hasFiles ? (
+          <ul className="mt-3 space-y-3">
+            {files.map((file) => (
+              <li key={file.id} className="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p className="font-medium text-gray-900 dark:text-gray-100">{file.originalName}</p>
+                  <span className="text-xs text-gray-500 dark:text-gray-400">{formatBytes(file.size)}</span>
+                </div>
+                <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                  <span>{formatTimestamp(file.createdAt)}</span>
+                  {file.contentType ? <span>• {file.contentType}</span> : null}
+                  {file.uploadedViaApi ? (
+                    <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200">
+                      Uploaded via API
+                    </span>
+                  ) : (
+                    <span className="rounded-full bg-blue-100 px-2 py-0.5 text-blue-700 dark:bg-blue-900/30 dark:text-blue-200">
+                      Direct upload
+                    </span>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">No files uploaded yet.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/projects/[id]/ProjectIngestionSettings.tsx
+++ b/src/app/projects/[id]/ProjectIngestionSettings.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = {
+  projectId: string;
+  initialEnabled: boolean;
+  initialToken: string | null;
+};
+
+type ApiResponse = {
+  apiIngestionEnabled: boolean;
+  apiToken: string | null;
+};
+
+async function copyToClipboard(value: string) {
+  try {
+    await navigator.clipboard.writeText(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function ProjectIngestionSettings({ projectId, initialEnabled, initialToken }: Props) {
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [token, setToken] = useState<string | null>(initialToken);
+  const [status, setStatus] = useState<"idle" | "loading">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const updateSettings = async (payload: Record<string, unknown>) => {
+    setStatus("loading");
+    setError(null);
+    try {
+      const response = await fetch(`/api/projects/${projectId}/ingestion`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok || !data) {
+        const message = data && typeof (data as any).error === "string" ? (data as any).error : "Unable to update settings";
+        throw new Error(message);
+      }
+      const parsed = data as ApiResponse;
+      setEnabled(parsed.apiIngestionEnabled);
+      setToken(parsed.apiToken ?? null);
+      setCopied(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to update settings");
+    } finally {
+      setStatus("idle");
+    }
+  };
+
+  const toggle = () => {
+    updateSettings({ apiIngestionEnabled: !enabled });
+  };
+
+  const regenerate = () => {
+    updateSettings({ regenerateToken: true, apiIngestionEnabled: true });
+  };
+
+  const handleCopy = async () => {
+    if (!token) return;
+    const success = await copyToClipboard(token);
+    setCopied(success);
+    if (!success) {
+      setError("Unable to copy token. Copy it manually.");
+    }
+  };
+
+  return (
+    <div className="card space-y-5">
+      <div>
+        <h2 className="text-xl font-semibold">API ingestion</h2>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+          Allow this project to receive files through the API. When enabled, use the generated token to authorize ingestion
+          requests.
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900">
+        <div>
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Enable API ingestion</p>
+          <p className="text-xs text-gray-600 dark:text-gray-400">External systems can push files with a bearer token.</p>
+        </div>
+        <label className="inline-flex cursor-pointer items-center gap-2 text-sm font-medium">
+          <span className="text-gray-600 dark:text-gray-400">{enabled ? "On" : "Off"}</span>
+          <input
+            type="checkbox"
+            className="h-5 w-10 cursor-pointer"
+            checked={enabled}
+            disabled={status === "loading"}
+            onChange={toggle}
+          />
+        </label>
+      </div>
+
+      {enabled && token ? (
+        <div className="space-y-3 rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium text-gray-900 dark:text-gray-100">API token</p>
+              <p className="text-xs text-gray-600 dark:text-gray-400">Send this token as a bearer credential.</p>
+            </div>
+            <button type="button" className="btn btn-secondary" onClick={regenerate} disabled={status === "loading"}>
+              Regenerate
+            </button>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <code className="flex-1 whitespace-pre-wrap break-all rounded bg-gray-100 px-3 py-2 text-sm text-gray-800 dark:bg-gray-800 dark:text-gray-100">
+              {token}
+            </code>
+            <button type="button" className="btn btn-outline" onClick={handleCopy} disabled={status === "loading"}>
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {enabled ? (
+        <div className="rounded-lg border border-gray-200 p-4 text-sm text-gray-600 dark:border-gray-700 dark:text-gray-300">
+          <p className="font-medium text-gray-800 dark:text-gray-100">Endpoint</p>
+          <pre className="mt-2 whitespace-pre-wrap rounded bg-gray-100 p-3 text-xs text-gray-800 dark:bg-gray-800 dark:text-gray-100">
+{`POST /api/projects/${projectId}/ingest
+Authorization: Bearer ${token ?? "<token>"}
+Content-Type: multipart/form-data`}
+          </pre>
+          <p className="mt-2">Attach the file in a form field named <code>file</code>.</p>
+        </div>
+      ) : null}
+
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+      {status === "loading" ? <p className="text-xs text-gray-500 dark:text-gray-400">Saving changes...</p> : null}
+    </div>
+  );
+}

--- a/src/db/migrations/006_project_files_ingestion.js
+++ b/src/db/migrations/006_project_files_ingestion.js
@@ -1,0 +1,50 @@
+const { sql } = require("kysely");
+
+/**
+ * @param {import('kysely').Kysely<any>} db
+ */
+async function up(db) {
+  await db.schema
+    .alterTable("project")
+    .addColumn("apiIngestionEnabled", "boolean", (col) => col.notNull().defaultTo(false))
+    .addColumn("apiToken", "text")
+    .execute();
+
+  await db.schema
+    .createTable("projectFile")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("projectId", "text", (col) =>
+      col.notNull().references("project.id").onDelete("cascade")
+    )
+    .addColumn("ownerId", "text", (col) =>
+      col.notNull().references("user.id").onDelete("cascade")
+    )
+    .addColumn("originalName", "text", (col) => col.notNull())
+    .addColumn("storagePath", "text", (col) => col.notNull())
+    .addColumn("contentType", "text")
+    .addColumn("size", "bigint", (col) => col.notNull())
+    .addColumn("uploadedViaApi", "boolean", (col) => col.notNull().defaultTo(false))
+    .addColumn("createdAt", "timestamp", (col) => col.notNull().defaultTo(sql`now()`))
+    .execute();
+
+  await db.schema
+    .createIndex("project_file_project_idx")
+    .on("projectFile")
+    .column("projectId")
+    .execute();
+}
+
+/**
+ * @param {import('kysely').Kysely<any>} db
+ */
+async function down(db) {
+  await db.schema.dropIndex("project_file_project_idx").ifExists().execute();
+  await db.schema.dropTable("projectFile").ifExists().execute();
+  await db.schema
+    .alterTable("project")
+    .dropColumn("apiToken")
+    .dropColumn("apiIngestionEnabled")
+    .execute();
+}
+
+module.exports = { up, down };

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,38 @@
+import { mkdir, writeFile } from "fs/promises";
+import { randomBytes } from "crypto";
+import path from "path";
+
+export function getStorageRoot(): string {
+  const configured = process.env.FILE_STORAGE_ROOT;
+  if (configured && configured.trim()) {
+    return path.resolve(configured);
+  }
+  return path.join(process.cwd(), "uploads");
+}
+
+function sanitizeFileName(fileName: string): string {
+  const base = path.basename(fileName).replace(/\\/g, "/");
+  const cleaned = base.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return cleaned || "upload";
+}
+
+export async function persistProjectFile(
+  projectId: string,
+  file: File,
+  preferredName?: string
+): Promise<{ relativePath: string; absolutePath: string }> {
+  const root = getStorageRoot();
+  const projectDir = path.join(root, projectId);
+  await mkdir(projectDir, { recursive: true });
+
+  const safeName = sanitizeFileName(preferredName ?? file.name ?? "upload");
+  const uniquePrefix = randomBytes(8).toString("hex");
+  const storedFileName = `${Date.now()}_${uniquePrefix}_${safeName}`;
+  const absolutePath = path.join(projectDir, storedFileName);
+  const relativePath = path.relative(root, absolutePath);
+
+  const arrayBuffer = await file.arrayBuffer();
+  await writeFile(absolutePath, Buffer.from(arrayBuffer));
+
+  return { relativePath, absolutePath };
+}


### PR DESCRIPTION
## Summary
- add a migration and storage helper so projects can persist uploaded files under a configurable root directory
- expose API routes to upload files directly, accept token-authenticated ingestion, and toggle per-project API access
- refresh the project page UI, environment sample, and docs with upload controls and API ingestion guidance

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c99d74c7708323a88bcf736f90b60f