### PR TITLE
Fix project file upload form event handling

### DIFF
--- a/src/app/projects/[id]/ProjectFilesPanel.tsx
+++ b/src/app/projects/[id]/ProjectFilesPanel.tsx
@@ -40,6 +40,7 @@ export function ProjectFilesPanel({ projectId, initialFiles }: Props) {
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    const form = event.currentTarget;
     if (!selectedFile || status === "uploading") return;
 
     setStatus("uploading");
@@ -62,7 +63,7 @@ export function ProjectFilesPanel({ projectId, initialFiles }: Props) {
       const uploaded = payload as ProjectFile;
       setFiles((previous) => [uploaded, ...previous]);
       setSelectedFile(null);
-      const input = event.currentTarget.elements.namedItem("file") as HTMLInputElement | null;
+      const input = form.elements.namedItem("file") as HTMLInputElement | null;
       if (input) {
         input.value = "";
       }


### PR DESCRIPTION
## Summary
- store the form element before async work when uploading files so we can safely reset the input after React releases the event

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9a4339d908323bfbfa1e3dc7ff2e0