### PR TITLE
Add OpenRouter processing tasks to backlog

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -2,6 +2,17 @@
 
 A running list of the major capabilities planned for extractPDF.
 
+Focus first on the OpenRouter integration items below—these unblock every other downstream workflow.
+
+## LLM Processing with OpenRouter
+- [ ] Surface OpenRouter API configuration in the dashboard, including project-level model selection and credential management.
+- [ ] Build a server-side OpenRouter client that composes prompts from instruction sets and dispatches document/page jobs.
+- [ ] Queue and orchestrate LLM calls so large documents process asynchronously with retries, backoff, and concurrency controls.
+- [ ] Persist raw LLM responses, extracted insights, and token/cost telemetry for each processing run.
+- [ ] Wire the processing pipeline into OCR and extraction outputs so every uploaded document can be sent to OpenRouter automatically.
+- [ ] Provide UI affordances to trigger processing, monitor job status, and review LLM results per document and page.
+- [ ] Implement guardrails for usage limits, error reporting, and developer-visible logs around OpenRouter requests.
+
 ## Instruction Sets
 - [x] Provide an instruction set that performs OCR on all text within each file.
 - [x] Provide an instruction set that returns complete textual and visual page breakdowns.
@@ -18,6 +29,9 @@ A running list of the major capabilities planned for extractPDF.
 - [x] Adapt the project UI to reflect the selected task, including field configuration for extraction workflows.
 
 ## Ingestion and Storage
-- [ ] Enable direct uploads of files into a project.
-- [ ] Enable optional API-based ingestion that can be toggled per project.
-- [ ] Revisit file storage so uploads can be stored outside the application server if needed.
+- [x] Enable direct uploads of files into a project.
+- [x] Enable optional API-based ingestion that can be toggled per project.
+- [x] Revisit file storage so uploads can be stored outside the application server if needed.
+- [ ] Allow project owners to delete uploaded files and remove the binaries from storage.
+- [ ] Provide download links or previews so users can review uploaded files without leaving the app.
+- [ ] Validate uploaded file types against each project's configured type and surface friendly errors.


### PR DESCRIPTION
## Summary
- emphasize that OpenRouter work is the top priority for the roadmap
- expand the task list with detailed OpenRouter integration, orchestration, and UI follow-ups

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9a8c3ce948323a4f79854724132a3