### PR TITLE
Add project file management controls

### DIFF
--- a/src/app/api/projects/[id]/files/[fileId]/route.ts
+++ b/src/app/api/projects/[id]/files/[fileId]/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest } from "next/server";
+
+import { getDb } from "@/db/client";
+import { getCurrentUserId } from "@/lib/auth";
+import { readStoredFile, removeStoredFile } from "@/lib/storage";
+
+type Params = { params: Promise<{ id: string; fileId: string }> };
+
+type ProjectRow = {
+  id: string;
+  ownerId: string;
+};
+
+type ProjectFileRow = {
+  id: string;
+  projectId: string;
+  storagePath: string;
+  originalName: string;
+  contentType: string | null;
+  size: string | number | bigint;
+};
+
+function normalizeSize(size: ProjectFileRow["size"]): number {
+  if (typeof size === "number") return size;
+  if (typeof size === "bigint") return Number(size);
+  const parsed = Number(size);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function buildContentDisposition(originalName: string, disposition: "inline" | "attachment"): string {
+  const fallback = originalName || "file";
+  const sanitized = fallback.replace(/["\r\n]/g, "_");
+  const safeName = sanitized || "file";
+  const encoded = encodeURIComponent(safeName);
+  return `${disposition}; filename="${safeName}"; filename*=UTF-8''${encoded}`;
+}
+
+export async function GET(request: NextRequest, { params }: Params) {
+  const { id, fileId } = await params;
+  const userId = await getCurrentUserId();
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const db = getDb() as any;
+  const project = (await db
+    .selectFrom("project")
+    .select(["id", "ownerId"])
+    .where("id", "=", id)
+    .executeTakeFirst()) as ProjectRow | undefined;
+
+  if (!project || project.ownerId !== userId) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const file = (await db
+    .selectFrom("projectFile")
+    .select(["id", "projectId", "storagePath", "originalName", "contentType", "size"])
+    .where("projectId", "=", project.id)
+    .where("id", "=", fileId)
+    .executeTakeFirst()) as ProjectFileRow | undefined;
+
+  if (!file) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  let fileContent: Buffer | null = null;
+  try {
+    fileContent = await readStoredFile(file.storagePath);
+  } catch (error) {
+    console.error("Failed to read stored file", error);
+    return Response.json({ error: "Unable to read the stored file." }, { status: 500 });
+  }
+
+  if (!fileContent) {
+    return Response.json({ error: "This file is no longer available." }, { status: 410 });
+  }
+
+  const headers = new Headers();
+  headers.set("Content-Type", file.contentType ?? "application/octet-stream");
+  const size = normalizeSize(file.size);
+  if (size > 0 && Number.isFinite(size)) {
+    headers.set("Content-Length", size.toString());
+  }
+  headers.set("Cache-Control", "private, max-age=0, must-revalidate");
+  const downloadFlag = request.nextUrl.searchParams.get("download");
+  const shouldDownload =
+    downloadFlag !== null && downloadFlag.toLowerCase() !== "false" && downloadFlag !== "0";
+  const disposition = shouldDownload ? "attachment" : "inline";
+  headers.set("Content-Disposition", buildContentDisposition(file.originalName, disposition));
+
+  const body = new Uint8Array(fileContent);
+  return new Response(body, { headers });
+}
+
+export async function DELETE(_request: NextRequest, { params }: Params) {
+  const { id, fileId } = await params;
+  const userId = await getCurrentUserId();
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const db = getDb() as any;
+  const project = (await db
+    .selectFrom("project")
+    .select(["id", "ownerId"])
+    .where("id", "=", id)
+    .executeTakeFirst()) as ProjectRow | undefined;
+
+  if (!project || project.ownerId !== userId) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const file = (await db
+    .selectFrom("projectFile")
+    .select(["id", "storagePath"])
+    .where("projectId", "=", project.id)
+    .where("id", "=", fileId)
+    .executeTakeFirst()) as { id: string; storagePath: string } | undefined;
+
+  if (!file) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  try {
+    await removeStoredFile(file.storagePath);
+  } catch (error) {
+    console.error("Failed to delete stored file", error);
+    return Response.json({ error: "Unable to remove the stored file." }, { status: 500 });
+  }
+
+  await db
+    .deleteFrom("projectFile")
+    .where("id", "=", file.id)
+    .executeTakeFirst();
+
+  return new Response(null, { status: 204 });
+}

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,0 +1,51 @@
+import path from "path";
+
+import type { FileType } from "./instruction-sets";
+
+const IMAGE_EXTENSIONS = new Set([
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".gif",
+  ".bmp",
+  ".tif",
+  ".tiff",
+  ".webp",
+  ".heic",
+  ".heif"
+]);
+
+const IMAGE_FILE_DESCRIPTION = "image files (JPEG, PNG, GIF, WebP, BMP, TIFF, or HEIC)";
+
+export type FileValidationResult =
+  | { ok: true }
+  | { ok: false; message: string };
+
+export function validateFileForProjectType(
+  fileName: string | undefined,
+  mimeType: string | null | undefined,
+  projectType: FileType
+): FileValidationResult {
+  const normalizedMime = (mimeType ?? "").toLowerCase();
+  const extension = path.extname(fileName ?? "").toLowerCase();
+
+  if (projectType === "pdf") {
+    const isPdfMime = normalizedMime === "application/pdf";
+    const isPdfExtension = extension === ".pdf";
+    if (isPdfMime || isPdfExtension) {
+      return { ok: true };
+    }
+    return { ok: false, message: "This project only accepts PDF files." };
+  }
+
+  if (projectType === "image") {
+    const isImageMime = normalizedMime.startsWith("image/");
+    const isImageExtension = IMAGE_EXTENSIONS.has(extension);
+    if (isImageMime || isImageExtension) {
+      return { ok: true };
+    }
+    return { ok: false, message: `This project only accepts ${IMAGE_FILE_DESCRIPTION}.` };
+  }
+
+  return { ok: true };
+}

--- a/tasks.md
+++ b/tasks.md
@@ -33,6 +33,6 @@ Focus first on the OpenRouter integration items below—these unblock every othe
 - [x] Enable direct uploads of files into a project.
 - [x] Enable optional API-based ingestion that can be toggled per project.
 - [x] Revisit file storage so uploads can be stored outside the application server if needed.
-- [ ] Allow project owners to delete uploaded files and remove the binaries from storage.
-- [ ] Provide download links or previews so users can review uploaded files without leaving the app.
-- [ ] Validate uploaded file types against each project's configured type and surface friendly errors.
+- [x] Allow project owners to delete uploaded files and remove the binaries from storage.
+- [x] Provide download links or previews so users can review uploaded files without leaving the app.
+- [x] Validate uploaded file types against each project's configured type and surface friendly errors.


### PR DESCRIPTION
## Summary
- enforce project-specific file type validation for direct and API uploads
- add APIs and storage helpers to download and delete project files while cleaning up binaries
- update the project files panel with open/download/delete actions and mark tasks complete

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9ac90e7b48323a2f1b9a358874b33