### PR TITLE
Document OpenRouter API key configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,8 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/extractpdf
 # Secret used by Better Auth for signing tokens
 BETTER_AUTH_SECRET=better-auth-secret-123456789
 
+# API key used to access OpenRouter LLMs
+OPENROUTER_API_KEY=your-openrouter-key
+
 # Directory for storing uploaded files (optional)
 FILE_STORAGE_ROOT=./uploads

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ A Next.js application that will power a PDF analysis platform. The project curre
 
 ## Getting Started
 
-1. Copy `.env.example` to `.env` and adjust the values.
+1. Copy `.env.example` to `.env` and adjust the values. Add your OpenRouter API key to the root-level `.env` file so the LLM client can authenticate:
+   ```bash
+   OPENROUTER_API_KEY=your_openrouter_key_here
+   ```
 2. Start a PostgreSQL database (e.g. `docker compose up db`).
 3. Install dependencies:
    ```bash


### PR DESCRIPTION
## Summary
- document where to add the OpenRouter API key in the getting started instructions
- include an `OPENROUTER_API_KEY` placeholder in `.env.example` so new environments are configured correctly

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bd279798832380c87b415fa43028