### PR TITLE
Revamp project page layout and processing results

### DIFF
--- a/src/app/projects/[id]/ProjectPageClient.tsx
+++ b/src/app/projects/[id]/ProjectPageClient.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import Link from "next/link";
+import type { ComponentProps } from "react";
+import { useState } from "react";
+import type { InstructionSet } from "@/lib/instruction-sets";
+import { ProjectFilesPanel } from "./ProjectFilesPanel";
+import { ProjectIngestionSettings } from "./ProjectIngestionSettings";
+import { ProjectProcessingRunsPanel } from "./ProjectProcessingRunsPanel";
+
+type SectionId = "overview" | "files" | "results";
+
+type ProjectForClient = {
+  id: string;
+  name: string;
+  description: string | null;
+  fileType: string;
+  instructionSetId: string | null;
+  customPrompt: string | null;
+  apiIngestionEnabled: boolean;
+  apiToken: string | null;
+};
+
+type FileTypeInfo = {
+  label: string;
+  description: string | null;
+};
+
+type FilesPanelProps = ComponentProps<typeof ProjectFilesPanel>;
+type ProcessingPanelProps = ComponentProps<typeof ProjectProcessingRunsPanel>;
+
+type Props = {
+  project: ProjectForClient;
+  fileType: FileTypeInfo;
+  instructionSet: InstructionSet | null;
+  files: FilesPanelProps["initialFiles"];
+  processingRuns: ProcessingPanelProps["initialRuns"];
+  processingSummary: ProcessingPanelProps["initialSummary"];
+};
+
+const NAV_SECTIONS: { id: SectionId; label: string; description: string }[] = [
+  {
+    id: "overview",
+    label: "Overview",
+    description: "Project metadata and instruction details"
+  },
+  {
+    id: "files",
+    label: "Files & ingestion",
+    description: "Manage uploads and API ingestion"
+  },
+  {
+    id: "results",
+    label: "Processing results",
+    description: "Inspect run history and outputs"
+  }
+];
+
+export function ProjectPageClient({
+  project,
+  fileType,
+  instructionSet,
+  files,
+  processingRuns,
+  processingSummary
+}: Props) {
+  const [activeSection, setActiveSection] = useState<SectionId>("overview");
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 px-4 py-6 lg:space-y-8 lg:px-8">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold heading-gradient">{project.name}</h1>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+            Manage ingestion, uploads, and processing results for this project.
+          </p>
+        </div>
+        <Link href="/dashboard" className="btn btn-sm btn-secondary">
+          Back
+        </Link>
+      </div>
+
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
+        <aside className="lg:w-64">
+          <nav
+            aria-label="Project sections"
+            role="tablist"
+            className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+          >
+            <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Navigate</p>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Switch between the main areas of the project workspace.
+            </p>
+            <div className="mt-4 flex gap-2 overflow-x-auto pb-1 lg:flex-col lg:overflow-visible lg:pb-0">
+              {NAV_SECTIONS.map((section) => {
+                const isActive = section.id === activeSection;
+                return (
+                  <button
+                    key={section.id}
+                    id={`project-section-${section.id}`}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    aria-controls={`project-panel-${section.id}`}
+                    onClick={() => setActiveSection(section.id)}
+                    className={`min-w-[220px] rounded-md px-3 py-2 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                      isActive
+                        ? "bg-blue-600 text-white shadow dark:bg-blue-500"
+                        : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                    }`}
+                  >
+                    <span className="font-medium leading-none">{section.label}</span>
+                    <span className="mt-1 block text-xs opacity-80">{section.description}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </nav>
+        </aside>
+
+        <main className="flex-1">
+          {NAV_SECTIONS.map((section) => {
+            const isActive = section.id === activeSection;
+            return (
+              <section
+                key={section.id}
+                id={`project-panel-${section.id}`}
+                role="tabpanel"
+                aria-labelledby={`project-section-${section.id}`}
+                hidden={!isActive}
+                className="space-y-6"
+              >
+                {section.id === "overview" ? (
+                  <OverviewSection project={project} fileType={fileType} instructionSet={instructionSet} />
+                ) : null}
+                {section.id === "files" ? (
+                  <FilesSection
+                    projectId={project.id}
+                    apiIngestionEnabled={project.apiIngestionEnabled}
+                    apiToken={project.apiToken}
+                    files={files}
+                  />
+                ) : null}
+                {section.id === "results" ? (
+                  <ResultsSection
+                    projectId={project.id}
+                    runs={processingRuns}
+                    summary={processingSummary}
+                  />
+                ) : null}
+              </section>
+            );
+          })}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+type OverviewProps = {
+  project: ProjectForClient;
+  fileType: FileTypeInfo;
+  instructionSet: InstructionSet | null;
+};
+
+function OverviewSection({ project, fileType, instructionSet }: OverviewProps) {
+  return (
+    <div className="space-y-6">
+      <div className="card space-y-8">
+        <div className="grid gap-6 md:grid-cols-2">
+          <div>
+            <p className="text-sm text-gray-500">Project ID</p>
+            <p className="mt-1 font-mono text-sm text-gray-800 dark:text-gray-200 md:text-base">{project.id}</p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-500">File type</p>
+            <p className="mt-1 text-base text-gray-900 dark:text-gray-100">{fileType.label}</p>
+            {fileType.description ? (
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{fileType.description}</p>
+            ) : null}
+          </div>
+          <div>
+            <p className="text-sm text-gray-500">Instruction set</p>
+            <p className="mt-1 text-base text-gray-900 dark:text-gray-100">
+              {instructionSet?.name ?? project.instructionSetId ?? "Custom"}
+            </p>
+            {instructionSet ? (
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{instructionSet.summary}</p>
+            ) : null}
+          </div>
+          <div>
+            <p className="text-sm text-gray-500">Description</p>
+            <p className="mt-1 text-sm text-gray-700 dark:text-gray-300">
+              {project.description ?? "No description provided."}
+            </p>
+          </div>
+        </div>
+
+        {project.customPrompt ? (
+          <div>
+            <p className="text-sm text-gray-500">Custom prompt</p>
+            <pre className="mt-2 whitespace-pre-wrap rounded-lg bg-gray-100 p-4 text-sm text-gray-700 dark:bg-gray-800 dark:text-gray-200">
+              {project.customPrompt}
+            </pre>
+          </div>
+        ) : null}
+      </div>
+
+      {instructionSet ? (
+        <div className="card space-y-6">
+          <div>
+            <h2 className="text-xl font-semibold">Instruction set overview</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">{instructionSet.summary}</p>
+          </div>
+
+          <div>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Processing steps</h3>
+            <ul className="mt-2 space-y-2 text-sm text-gray-700 dark:text-gray-300">
+              {instructionSet.steps.map((step) => (
+                <li key={step} className="flex gap-2">
+                  <span className="mt-1 text-gray-400">•</span>
+                  <span>{step}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Outputs</h3>
+            <ul className="mt-2 space-y-2 text-sm text-gray-700 dark:text-gray-300">
+              {instructionSet.outputs.map((output) => (
+                <li key={output} className="flex gap-2">
+                  <span className="mt-1 text-gray-400">•</span>
+                  <span>{output}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Field schema</h3>
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              {instructionSet.fields.map((field) => (
+                <div key={field.name} className="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+                  <p className="font-medium text-gray-900 dark:text-gray-100">{field.name}</p>
+                  <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">{field.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type FilesSectionProps = {
+  projectId: string;
+  apiIngestionEnabled: boolean;
+  apiToken: string | null;
+  files: FilesPanelProps["initialFiles"];
+};
+
+function FilesSection({ projectId, apiIngestionEnabled, apiToken, files }: FilesSectionProps) {
+  return (
+    <div className="space-y-6">
+      <ProjectIngestionSettings
+        projectId={projectId}
+        initialEnabled={apiIngestionEnabled}
+        initialToken={apiToken}
+      />
+      <ProjectFilesPanel projectId={projectId} initialFiles={files} />
+    </div>
+  );
+}
+
+type ResultsSectionProps = {
+  projectId: string;
+  runs: ProcessingPanelProps["initialRuns"];
+  summary: ProcessingPanelProps["initialSummary"];
+};
+
+function ResultsSection({ projectId, runs, summary }: ResultsSectionProps) {
+  return (
+    <div className="space-y-6">
+      <ProjectProcessingRunsPanel projectId={projectId} initialRuns={runs} initialSummary={summary} />
+    </div>
+  );
+}

--- a/src/app/projects/[id]/ProjectProcessingRunsPanel.tsx
+++ b/src/app/projects/[id]/ProjectProcessingRunsPanel.tsx
@@ -231,7 +231,7 @@ export function ProjectProcessingRunsPanel({ projectId, initialRuns, initialSumm
   const activeLabel = hasActiveRuns ? `${summary.active} active` : "No active runs";
 
   return (
-    <div className="card space-y-5">
+    <div className="card space-y-6">
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
           <h2 className="text-xl font-semibold">Processing runs</h2>
@@ -252,8 +252,8 @@ export function ProjectProcessingRunsPanel({ projectId, initialRuns, initialSumm
         </div>
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
-        <div className="space-y-4">
+      <div className="grid gap-6 lg:grid-cols-[360px_minmax(0,1fr)] xl:grid-cols-[420px_minmax(0,1fr)]">
+        <div className="space-y-6">
           <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm dark:border-gray-700 dark:bg-gray-900">
             <p className="font-medium text-gray-900 dark:text-gray-100">Usage summary</p>
             <div className="mt-2 space-y-1 text-xs text-gray-600 dark:text-gray-400">
@@ -317,7 +317,7 @@ export function ProjectProcessingRunsPanel({ projectId, initialRuns, initialSumm
           </div>
         </div>
 
-        <div className="space-y-4">
+        <div className="space-y-6">
           {selectedRunId ? (
             <RunDetailView
               runId={selectedRunId}
@@ -374,16 +374,18 @@ function RunDetailView({
   const { run, file, pages, events } = detail;
 
   return (
-    <div className="space-y-4">
-      <div className="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+    <div className="space-y-6">
+      <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <div>
-            <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Run {run.id}</p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Instruction set: {run.instructionSet ?? "Custom"}</p>
+            <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Run {run.id}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Instruction set: {run.instructionSet ?? "Custom"}
+            </p>
           </div>
           <StatusBadge status={run.status} />
         </div>
-        <div className="mt-3 grid gap-3 text-xs text-gray-600 dark:text-gray-400 md:grid-cols-2">
+        <div className="mt-4 grid gap-3 text-xs text-gray-600 dark:text-gray-400 md:grid-cols-2">
           <p>Model: {run.model ?? "Default"}</p>
           <p>Temperature: {run.temperature ?? "—"}</p>
           <p>Created: {formatDate(run.createdAt)}</p>
@@ -392,13 +394,14 @@ function RunDetailView({
           <p>Attempts: {run.attempts}</p>
         </div>
         {file ? (
-          <div className="mt-3 rounded-md bg-gray-50 p-3 text-xs text-gray-600 dark:bg-gray-900 dark:text-gray-300">
-            <p className="font-medium text-gray-800 dark:text-gray-200">{file.originalName ?? file.id}</p>
-            <p className="mt-1 flex flex-wrap gap-4">
+          <div className="mt-4 rounded-md border border-gray-200 bg-gray-50 p-3 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-900/60 dark:text-gray-300">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Source file</p>
+            <p className="mt-1 font-medium text-gray-900 dark:text-gray-100">{file.originalName ?? file.id}</p>
+            <div className="mt-2 flex flex-wrap gap-4">
               <span>Size: {formatBytes(file.size)}</span>
               <span>Type: {file.contentType ?? "Unknown"}</span>
               <span>Uploaded: {formatDate(file.createdAt)}</span>
-            </p>
+            </div>
           </div>
         ) : null}
         {run.error ? (
@@ -412,38 +415,51 @@ function RunDetailView({
           </ul>
         ) : null}
         {run.customPrompt ? (
-          <details className="mt-3 text-xs">
-            <summary className="cursor-pointer text-gray-700 dark:text-gray-300">Custom prompt</summary>
-            <pre className="mt-2 max-h-40 overflow-auto rounded bg-gray-100 p-3 text-[11px] text-gray-800 dark:bg-gray-800 dark:text-gray-200">
+          <details className="mt-4 text-xs">
+            <summary className="cursor-pointer font-semibold text-gray-700 dark:text-gray-200">Custom prompt</summary>
+            <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-words rounded bg-gray-100 p-3 text-[11px] text-gray-800 dark:bg-gray-800 dark:text-gray-200">
               {run.customPrompt}
             </pre>
           </details>
         ) : null}
         {run.usageSummary ? (
-          <div className="mt-3 grid gap-3 rounded-md bg-gray-50 p-3 text-xs text-gray-600 dark:bg-gray-900 dark:text-gray-300 md:grid-cols-2">
+          <div className="mt-4 grid gap-3 rounded-md border border-gray-200 bg-gray-50 p-3 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-900/60 dark:text-gray-300 md:grid-cols-2">
             <p>Total tokens: {formatTokens(run.usageSummary?.totalTokens)}</p>
             <p>Total cost (USD): {formatCost(run.usageSummary?.totalCostUsd)}</p>
             <p>Prompt tokens: {formatTokens(run.usageSummary?.promptTokens)}</p>
             <p>Completion tokens: {formatTokens(run.usageSummary?.completionTokens)}</p>
           </div>
         ) : null}
-      </div>
+      </section>
 
       {run.aggregatedOutput ? (
-        <div className="rounded-lg border border-gray-200 p-4 text-sm dark:border-gray-700">
-          <p className="font-medium text-gray-900 dark:text-gray-100">Aggregated output</p>
-          <pre className="mt-2 max-h-64 overflow-auto rounded bg-gray-100 p-3 text-xs text-gray-800 dark:bg-gray-800 dark:text-gray-200">
+        <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Aggregated output</p>
+            <span className="text-xs text-gray-500 dark:text-gray-400">Combined structured result</span>
+          </div>
+          <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-words rounded bg-gray-100 p-3 text-xs text-gray-800 dark:bg-gray-800 dark:text-gray-200">
             {stringify(run.aggregatedOutput)}
           </pre>
-        </div>
+        </section>
       ) : null}
 
-      <div className="space-y-3">
-        <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Page results</p>
+      <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Page results</p>
+          {pages.length ? (
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {pages.length} page{pages.length === 1 ? "" : "s"} processed
+            </span>
+          ) : null}
+        </div>
         {pages.length ? (
-          <div className="space-y-3">
+          <div className="mt-4 space-y-4">
             {pages.map((page) => (
-              <div key={page.id} className="rounded-lg border border-gray-200 p-4 text-sm dark:border-gray-700">
+              <article
+                key={page.id}
+                className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm dark:border-gray-700 dark:bg-gray-900/60"
+              >
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <p className="font-medium text-gray-900 dark:text-gray-100">Page {page.pageNumber}</p>
                   <StatusBadge status={page.status} />
@@ -463,48 +479,61 @@ function RunDetailView({
                   </ul>
                 ) : null}
                 {page.entries.length ? (
-                  <details className="mt-3">
-                    <summary className="cursor-pointer text-xs font-medium text-gray-700 dark:text-gray-300">
-                      View structured entries
+                  <details className="mt-3 rounded-lg border border-gray-200 bg-white p-3 text-xs dark:border-gray-700 dark:bg-gray-900">
+                    <summary className="flex cursor-pointer items-center justify-between font-semibold text-gray-700 dark:text-gray-200">
+                      Structured entries
+                      <span className="text-[11px] font-normal text-gray-500 dark:text-gray-400">
+                        {page.entries.length} item{page.entries.length === 1 ? "" : "s"}
+                      </span>
                     </summary>
-                    <pre className="mt-2 max-h-60 overflow-auto rounded bg-gray-100 p-3 text-xs text-gray-800 dark:bg-gray-800 dark:text-gray-200">
+                    <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-words rounded bg-gray-100 p-3 text-[11px] text-gray-800 dark:bg-gray-800 dark:text-gray-200">
                       {stringify(page.entries)}
                     </pre>
                   </details>
                 ) : null}
                 {page.rawResponse ? (
-                  <details className="mt-3">
-                    <summary className="cursor-pointer text-xs font-medium text-gray-700 dark:text-gray-300">
+                  <details className="mt-3 rounded-lg border border-gray-200 bg-white p-3 text-xs dark:border-gray-700 dark:bg-gray-900">
+                    <summary className="flex cursor-pointer items-center justify-between font-semibold text-gray-700 dark:text-gray-200">
                       Raw LLM response
                     </summary>
-                    <pre className="mt-2 max-h-60 overflow-auto rounded bg-gray-100 p-3 text-xs text-gray-800 dark:bg-gray-800 dark:text-gray-200">
+                    <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-words rounded bg-gray-100 p-3 text-[11px] text-gray-800 dark:bg-gray-800 dark:text-gray-200">
                       {page.rawResponse}
                     </pre>
                   </details>
                 ) : null}
-              </div>
+              </article>
             ))}
           </div>
         ) : (
-          <p className="rounded-lg border border-dashed border-gray-300 p-4 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
+          <p className="mt-3 rounded-lg border border-dashed border-gray-300 p-4 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
             No page-level responses were recorded for this run.
           </p>
         )}
-      </div>
+      </section>
 
-      <div className="space-y-2">
-        <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Event log</p>
+      <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Event log</p>
+          {events.length ? (
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {events.length} entr{events.length === 1 ? "y" : "ies"}
+            </span>
+          ) : null}
+        </div>
         {events.length ? (
-          <ul className="max-h-64 space-y-2 overflow-y-auto pr-1 text-xs text-gray-600 dark:text-gray-400">
+          <ul className="mt-4 space-y-3 text-xs text-gray-600 dark:text-gray-400">
             {events.map((event) => (
-              <li key={event.id} className="rounded border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900">
+              <li
+                key={event.id}
+                className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/60"
+              >
                 <div className="flex items-center justify-between gap-2">
                   <span className="font-medium text-gray-800 dark:text-gray-200">{event.level.toUpperCase()}</span>
                   <span>{formatDate(event.createdAt)}</span>
                 </div>
                 <p className="mt-1 text-gray-700 dark:text-gray-200">{event.message}</p>
                 {event.context ? (
-                  <pre className="mt-2 max-h-40 overflow-auto rounded bg-gray-100 p-2 text-[11px] text-gray-800 dark:bg-gray-800 dark:text-gray-200">
+                  <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-words rounded bg-gray-100 p-2 text-[11px] text-gray-800 dark:bg-gray-800 dark:text-gray-200">
                     {stringify(event.context)}
                   </pre>
                 ) : null}
@@ -512,11 +541,11 @@ function RunDetailView({
             ))}
           </ul>
         ) : (
-          <p className="rounded border border-dashed border-gray-300 p-4 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
+          <p className="mt-3 rounded border border-dashed border-gray-300 p-4 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
             No events recorded for this run.
           </p>
         )}
-      </div>
+      </section>
     </div>
   );
 }

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -4,9 +4,7 @@ import { getDb } from "@/db/client";
 import { getCurrentUserId } from "@/lib/auth";
 import { FILE_TYPES, getInstructionSet } from "@/lib/instruction-sets";
 import { listRunsForProject } from "@/lib/processing-service";
-import { ProjectFilesPanel } from "./ProjectFilesPanel";
-import { ProjectIngestionSettings } from "./ProjectIngestionSettings";
-import { ProjectProcessingRunsPanel } from "./ProjectProcessingRunsPanel";
+import { ProjectPageClient } from "./ProjectPageClient";
 
 type ProjectRecord = {
   id: string;
@@ -120,106 +118,30 @@ export default async function ProjectPage({ params }: { params: { id: string } }
     { totalTokens: 0, totalCostUsd: 0, active: 0 }
   );
 
+  const fileTypeLabel = fileType?.label ?? project.fileType;
+  const fileTypeDescription = fileType?.description ?? null;
+
   return (
-    <div className="mx-auto max-w-3xl space-y-8">
-      <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold heading-gradient">{project.name}</h1>
-        <Link href="/dashboard" className="btn btn-sm btn-secondary">
-          Back
-        </Link>
-      </div>
-
-      <div className="card space-y-8">
-        <div className="grid gap-6 sm:grid-cols-2">
-          <div>
-            <p className="text-sm text-gray-500">Project ID</p>
-            <p className="font-mono text-lg">{project.id}</p>
-          </div>
-          <div>
-            <p className="text-sm text-gray-500">File type</p>
-            <p className="text-lg">{fileType?.label ?? project.fileType}</p>
-            {fileType ? <p className="mt-1 text-xs text-gray-500">{fileType.description}</p> : null}
-          </div>
-          <div>
-            <p className="text-sm text-gray-500">Instruction set</p>
-            <p className="text-lg">{instructionSet?.name ?? project.instructionSet ?? "Custom"}</p>
-            {instructionSet ? <p className="mt-1 text-xs text-gray-500">{instructionSet.summary}</p> : null}
-          </div>
-          <div>
-            <p className="text-sm text-gray-500">Description</p>
-            <p className="text-gray-700 dark:text-gray-300">{project.description ?? "No description provided."}</p>
-          </div>
-        </div>
-
-        {project.customPrompt ? (
-          <div>
-            <p className="text-sm text-gray-500">Custom prompt</p>
-            <pre className="mt-2 whitespace-pre-wrap rounded-lg bg-gray-100 p-4 text-sm text-gray-700 dark:bg-gray-800 dark:text-gray-200">
-              {project.customPrompt}
-            </pre>
-          </div>
-        ) : null}
-      </div>
-
-      <ProjectIngestionSettings
-        projectId={project.id}
-        initialEnabled={project.apiIngestionEnabled}
-        initialToken={project.apiToken}
-      />
-
-      <ProjectFilesPanel projectId={project.id} initialFiles={files} />
-
-      <ProjectProcessingRunsPanel
-        projectId={project.id}
-        initialRuns={processingRuns}
-        initialSummary={processingSummary}
-      />
-
-      {instructionSet ? (
-        <div className="card space-y-6">
-          <div>
-            <h2 className="text-xl font-semibold">Instruction set overview</h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">{instructionSet.summary}</p>
-          </div>
-
-          <div>
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Processing steps</h3>
-            <ul className="mt-2 space-y-2 text-sm text-gray-700 dark:text-gray-300">
-              {instructionSet.steps.map((step) => (
-                <li key={step} className="flex gap-2">
-                  <span className="mt-1 text-gray-400">•</span>
-                  <span>{step}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          <div>
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Outputs</h3>
-            <ul className="mt-2 space-y-2 text-sm text-gray-700 dark:text-gray-300">
-              {instructionSet.outputs.map((output) => (
-                <li key={output} className="flex gap-2">
-                  <span className="mt-1 text-gray-400">•</span>
-                  <span>{output}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          <div>
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Field schema</h3>
-            <div className="mt-3 grid gap-3 sm:grid-cols-2">
-              {instructionSet.fields.map((field) => (
-                <div key={field.name} className="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
-                  <p className="font-medium text-gray-900 dark:text-gray-100">{field.name}</p>
-                  <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">{field.description}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      ) : null}
-    </div>
+    <ProjectPageClient
+      project={{
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        fileType: project.fileType,
+        instructionSetId: project.instructionSet,
+        customPrompt: project.customPrompt,
+        apiIngestionEnabled: project.apiIngestionEnabled,
+        apiToken: project.apiToken
+      }}
+      fileType={{
+        label: fileTypeLabel,
+        description: fileTypeDescription
+      }}
+      instructionSet={instructionSet}
+      files={files}
+      processingRuns={processingRuns}
+      processingSummary={processingSummary}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary
- expand the project page layout into a wider shell with side navigation to switch between overview, ingestion/files, and processing results sections
- preserve existing data fetching while funneling project, file, and run details through a new client component for sectioned rendering
- refresh the processing runs panel to widen the detail column and remove truncated output with clearer cards for run summaries, page data, and event logs

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cae36f127c832392926bd8da2d9c76