### PR TITLE
Add zip ingestion, processing aggregation, and progress tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/forms": "^0.5.10",
         "better-auth": "^1.3.9",
+        "jszip": "^3.10.1",
         "kysely": "^0.28.5",
         "next": "15.5.2",
         "next-themes": "^0.4.6",
@@ -20,6 +21,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.13",
+        "@types/jszip": "^3.4.0",
         "@types/node": "^20",
         "@types/pdf-parse": "^1.1.5",
         "@types/pg": "^8.15.5",
@@ -1098,6 +1100,16 @@
         "tailwindcss": "4.1.13"
       }
     },
+    "node_modules/@types/jszip": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.4.0.tgz",
+      "integrity": "sha512-GFHqtQQP3R4NNuvZH3hNCYD0NbyBZ42bkN7kO3NDrU/SnvIZWMS8Bp38XCsRKBT5BXvgm0y1zqpZWp/ZkRzBzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jszip": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
@@ -1374,6 +1386,12 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -1458,12 +1476,30 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/jiti": {
       "version": "2.5.1",
@@ -1484,6 +1520,18 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/kysely": {
       "version": "0.28.5",
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.5.tgz",
@@ -1491,6 +1539,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -1942,6 +1999,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/pdf-parse": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
@@ -2125,6 +2188,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/pvtsutils": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
@@ -2164,10 +2233,31 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/rou3": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.5.1.tgz",
       "integrity": "sha512-OXMmJ3zRk2xeXFGfA3K+EOPHC5u7RDFG7lIOx0X1pdnhUkI8MdVrbV+sNsD80ElpUZ+MRHdyxPnFthq9VHs8uQ==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/scheduler": {
@@ -2193,6 +2283,12 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
     "node_modules/sharp": {
@@ -2264,6 +2360,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/styled-jsx": {
@@ -2390,6 +2495,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tailwindcss/forms": "^0.5.10",
     "better-auth": "^1.3.9",
+    "jszip": "^3.10.1",
     "kysely": "^0.28.5",
     "next": "15.5.2",
     "next-themes": "^0.4.6",
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.13",
+    "@types/jszip": "^3.4.0",
     "@types/node": "^20",
     "@types/pdf-parse": "^1.1.5",
     "@types/pg": "^8.15.5",

--- a/src/app/api/projects/[id]/files/route.ts
+++ b/src/app/api/projects/[id]/files/route.ts
@@ -1,12 +1,13 @@
-import { generateId } from "better-auth";
 import { NextRequest } from "next/server";
+
 import { getDb } from "@/db/client";
 import { getCurrentUserId } from "@/lib/auth";
-import { persistProjectFile } from "@/lib/storage";
-import { validateFileForProjectType } from "@/lib/files";
 import type { FileType } from "@/lib/instruction-sets";
-import { queueProcessingForFile } from "@/lib/processing-service";
-import { enqueueProcessingRun } from "@/lib/processing-queue";
+import {
+  normalizeProjectFileRow,
+  saveProjectUpload,
+  UploadError
+} from "@/lib/project-file-upload";
 
 const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024; // 25 MB per upload
 
@@ -21,25 +22,11 @@ type ProjectRow = {
 type ProjectFileRow = {
   id: string;
   originalName: string;
-  size: string | number;
+  size: string | number | bigint;
   contentType: string | null;
   uploadedViaApi: boolean;
   createdAt: Date | string;
 };
-
-function normalizeFileRow(row: ProjectFileRow) {
-  return {
-    id: row.id,
-    originalName: row.originalName,
-    size: typeof row.size === "string" ? Number(row.size) : row.size,
-    contentType: row.contentType,
-    uploadedViaApi: row.uploadedViaApi,
-    createdAt:
-      row.createdAt instanceof Date
-        ? row.createdAt.toISOString()
-        : new Date(row.createdAt).toISOString()
-  };
-}
 
 export async function GET(_request: NextRequest, { params }: Params) {
   const { id } = await params;
@@ -64,7 +51,7 @@ export async function GET(_request: NextRequest, { params }: Params) {
     .orderBy("createdAt", "desc")
     .execute()) as ProjectFileRow[];
 
-  return Response.json(files.map(normalizeFileRow));
+  return Response.json(files.map(normalizeProjectFileRow));
 }
 
 export async function POST(request: NextRequest, { params }: Params) {
@@ -90,58 +77,31 @@ export async function POST(request: NextRequest, { params }: Params) {
   }
 
   const upload = file as File;
-  if (upload.size > MAX_FILE_SIZE_BYTES) {
-    return Response.json({ error: "File exceeds size limit" }, { status: 413 });
-  }
-
-  const validation = validateFileForProjectType(upload.name, upload.type, project.fileType);
-  if (!validation.ok) {
-    return Response.json({ error: validation.message }, { status: 415 });
-  }
-
-  const { relativePath } = await persistProjectFile(project.id, upload);
-
-  const fileId = generateId();
-  await db
-    .insertInto("projectFile")
-    .values({
-      id: fileId,
+  try {
+    const outcome = await saveProjectUpload({
       projectId: project.id,
       ownerId: userId,
-      originalName: upload.name,
-      storagePath: relativePath,
-      contentType: upload.type || null,
-      size: BigInt(upload.size),
-      uploadedViaApi: false
-    })
-    .executeTakeFirst();
-
-  let processingRunId: string | null = null;
-  try {
-    const run = await queueProcessingForFile({
-      projectId: project.id,
-      fileId,
-      triggeredBy: userId
-    });
-    if (run?.runId) {
-      processingRunId = run.runId;
-      enqueueProcessingRun(run.runId);
-    }
-  } catch (error) {
-    console.error("Failed to enqueue processing run", error);
-  }
-
-  const payload = {
-    ...normalizeFileRow({
-      id: fileId,
-      originalName: upload.name,
-      size: upload.size,
-      contentType: upload.type || null,
+      projectType: project.fileType,
+      upload,
       uploadedViaApi: false,
-      createdAt: new Date()
-    }),
-    processingRunId
-  };
+      triggeredBy: userId,
+      maxFileSizeBytes: MAX_FILE_SIZE_BYTES
+    });
 
-  return Response.json(payload);
+    const primaryRunId = outcome.processingRunIds[0] ?? null;
+
+    return Response.json({
+      file: outcome.files[0] ?? null,
+      files: outcome.files,
+      processingRunId: primaryRunId,
+      processingRunIds: outcome.processingRunIds,
+      warnings: outcome.warnings
+    });
+  } catch (error) {
+    if (error instanceof UploadError) {
+      return Response.json({ error: error.message }, { status: error.status });
+    }
+    console.error("Failed to upload project files", error);
+    return Response.json({ error: "Upload failed" }, { status: 500 });
+  }
 }

--- a/src/app/api/projects/[id]/processing/aggregate/route.ts
+++ b/src/app/api/projects/[id]/processing/aggregate/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+
+import { getDb } from "@/db/client";
+import { getCurrentUserId } from "@/lib/auth";
+import { aggregateResultsByFolder } from "@/lib/processing-service";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const db = getDb() as any;
+  const project = await db
+    .selectFrom("project")
+    .select(["id", "ownerId"])
+    .where("id", "=", id)
+    .executeTakeFirst();
+
+  if (!project || project.ownerId !== userId) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const nodes = await aggregateResultsByFolder(id);
+  return Response.json({ nodes });
+}

--- a/src/app/api/projects/[id]/processing/progress/route.ts
+++ b/src/app/api/projects/[id]/processing/progress/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+
+import { getDb } from "@/db/client";
+import { getCurrentUserId } from "@/lib/auth";
+import { getProcessingProgress } from "@/lib/processing-service";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const db = getDb() as any;
+  const project = await db
+    .selectFrom("project")
+    .select(["id", "ownerId"])
+    .where("id", "=", id)
+    .executeTakeFirst();
+
+  if (!project || project.ownerId !== userId) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const progress = await getProcessingProgress(id);
+  return Response.json(progress);
+}

--- a/src/app/projects/[id]/ProjectFilesPanel.tsx
+++ b/src/app/projects/[id]/ProjectFilesPanel.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+
+import type { ProcessingProgressSnapshot } from "@/lib/processing-types";
 
 type ProjectFile = {
   id: string;
@@ -14,6 +16,8 @@ type ProjectFile = {
 type Props = {
   projectId: string;
   initialFiles: ProjectFile[];
+  progress: ProcessingProgressSnapshot;
+  onProgressChange: (progress: ProcessingProgressSnapshot) => void;
 };
 
 function formatBytes(size: number): string {
@@ -30,14 +34,76 @@ function formatTimestamp(timestamp: string): string {
   return date.toLocaleString();
 }
 
-export function ProjectFilesPanel({ projectId, initialFiles }: Props) {
+function parseUploadResponse(payload: unknown): { files: ProjectFile[]; warnings: string[] } {
+  if (!payload || typeof payload !== "object") {
+    return { files: [], warnings: [] };
+  }
+
+  const data = payload as Record<string, unknown>;
+  const rawFiles = Array.isArray(data.files)
+    ? data.files
+    : data.file && typeof data.file === "object"
+      ? [data.file]
+      : [];
+
+  const files: ProjectFile[] = rawFiles.filter((entry): entry is ProjectFile => {
+    if (!entry || typeof entry !== "object") return false;
+    const candidate = entry as ProjectFile;
+    return typeof candidate.id === "string" && typeof candidate.originalName === "string";
+  });
+
+  const warnings = Array.isArray(data.warnings)
+    ? data.warnings.filter((warning): warning is string => typeof warning === "string")
+    : [];
+
+  return { files, warnings };
+}
+
+export function ProjectFilesPanel({ projectId, initialFiles, progress, onProgressChange }: Props) {
   const [files, setFiles] = useState<ProjectFile[]>(initialFiles);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [status, setStatus] = useState<"idle" | "uploading">("idle");
   const [error, setError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [progressLoading, setProgressLoading] = useState(false);
+  const [progressError, setProgressError] = useState<string | null>(null);
+  const [uploadWarnings, setUploadWarnings] = useState<string[]>([]);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const hasFiles = useMemo(() => files.length > 0, [files]);
+  const completionRatio = useMemo(() => {
+    if (!progress || progress.totalFiles <= 0) {
+      return 0;
+    }
+    const ratio = progress.completedFiles / progress.totalFiles;
+    return Number.isFinite(ratio) ? Math.min(Math.max(ratio, 0), 1) : 0;
+  }, [progress.completedFiles, progress.totalFiles]);
+  const progressPercent = Math.round(completionRatio * 100);
+  const progressWidth = Math.min(100, Math.max(0, progressPercent));
+  const progressSummary = progress.totalFiles > 0
+    ? `${progress.completedFiles} of ${progress.totalFiles} files processed`
+    : "No files uploaded yet.";
+  const activeLabel = progress.activeFiles > 0 ? `${progress.activeFiles} currently processing` : null;
+
+  const refreshProgress = useCallback(async () => {
+    setProgressLoading(true);
+    setProgressError(null);
+    try {
+      const response = await fetch(`/api/projects/${projectId}/processing/progress`);
+      if (!response.ok) {
+        throw new Error(`Failed to load progress (${response.status})`);
+      }
+      const payload = (await response.json().catch(() => null)) as ProcessingProgressSnapshot | null;
+      if (!payload || typeof payload.totalFiles !== "number") {
+        throw new Error("Unexpected response when loading progress");
+      }
+      onProgressChange(payload);
+    } catch (err) {
+      setProgressError(err instanceof Error ? err.message : "Unable to refresh progress");
+    } finally {
+      setProgressLoading(false);
+    }
+  }, [projectId, onProgressChange]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -46,6 +112,8 @@ export function ProjectFilesPanel({ projectId, initialFiles }: Props) {
 
     setStatus("uploading");
     setError(null);
+    setSuccessMessage(null);
+    setUploadWarnings([]);
     try {
       const formData = new FormData();
       formData.append("file", selectedFile);
@@ -61,13 +129,28 @@ export function ProjectFilesPanel({ projectId, initialFiles }: Props) {
         throw new Error(message);
       }
 
-      const uploaded = payload as ProjectFile;
-      setFiles((previous) => [uploaded, ...previous]);
+      const { files: uploadedFiles, warnings } = parseUploadResponse(payload);
+      if (!uploadedFiles.length) {
+        const message =
+          payload && typeof (payload as any).error === "string"
+            ? (payload as any).error
+            : "Upload succeeded but returned no files.";
+        throw new Error(message);
+      }
+
+      setFiles((previous) => [...uploadedFiles, ...previous]);
+      setUploadWarnings(warnings);
+      setSuccessMessage(
+        uploadedFiles.length === 1
+          ? `Uploaded ${uploadedFiles[0].originalName}.`
+          : `Uploaded ${uploadedFiles.length} files.`
+      );
       setSelectedFile(null);
       const input = form.elements.namedItem("file") as HTMLInputElement | null;
       if (input) {
         input.value = "";
       }
+      await refreshProgress();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Upload failed");
     } finally {
@@ -83,6 +166,7 @@ export function ProjectFilesPanel({ projectId, initialFiles }: Props) {
     setDeletingId(fileId);
     setError(null);
     try {
+      const target = files.find((file) => file.id === fileId);
       const response = await fetch(`/api/projects/${projectId}/files/${fileId}`, {
         method: "DELETE"
       });
@@ -97,6 +181,9 @@ export function ProjectFilesPanel({ projectId, initialFiles }: Props) {
       }
 
       setFiles((previous) => previous.filter((file) => file.id !== fileId));
+      setSuccessMessage(target ? `Removed ${target.originalName}.` : "File removed.");
+      setUploadWarnings([]);
+      await refreshProgress();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete file");
     } finally {
@@ -112,9 +199,52 @@ export function ProjectFilesPanel({ projectId, initialFiles }: Props) {
           Upload PDF or image files directly into this project. Files are stored in the configured storage directory so they
           can be processed later.
         </p>
-      </div>
+    </div>
 
-      <form onSubmit={handleSubmit} className="space-y-3 rounded-lg border border-dashed border-gray-300 p-4 dark:border-gray-700">
+    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Processing progress</p>
+          <p className="text-xs text-gray-600 dark:text-gray-400">{progressSummary}</p>
+        </div>
+        <button
+          type="button"
+          className="btn btn-sm btn-outline"
+          onClick={() => refreshProgress()}
+          disabled={progressLoading}
+        >
+          {progressLoading ? "Refreshing..." : "Refresh"}
+        </button>
+      </div>
+      <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-800">
+        <div
+          className="h-full rounded-full bg-blue-600 transition-all dark:bg-blue-500"
+          style={{ width: `${progressWidth}%` }}
+        />
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+        <span>{progressPercent}% complete</span>
+        {activeLabel ? <span>• {activeLabel}</span> : null}
+      </div>
+      {progressError ? <p className="mt-2 text-xs text-red-600 dark:text-red-400">{progressError}</p> : null}
+    </div>
+
+    {successMessage ? (
+      <p className="text-sm text-emerald-600 dark:text-emerald-300">{successMessage}</p>
+    ) : null}
+
+    {uploadWarnings.length ? (
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 dark:border-amber-400/50 dark:bg-amber-900/30 dark:text-amber-100">
+        <p className="font-medium">Archive warnings</p>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          {uploadWarnings.map((warning) => (
+            <li key={warning}>{warning}</li>
+          ))}
+        </ul>
+      </div>
+    ) : null}
+
+    <form onSubmit={handleSubmit} className="space-y-3 rounded-lg border border-dashed border-gray-300 p-4 dark:border-gray-700">
         <label className="block text-sm font-medium">Upload a file</label>
         <input
           type="file"

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { getDb } from "@/db/client";
 import { getCurrentUserId } from "@/lib/auth";
 import { FILE_TYPES, getInstructionSet } from "@/lib/instruction-sets";
-import { listRunsForProject } from "@/lib/processing-service";
+import { getProcessingProgress, listRunsForProject } from "@/lib/processing-service";
 import { ProjectPageClient } from "./ProjectPageClient";
 
 type ProjectRecord = {
@@ -121,6 +121,8 @@ export default async function ProjectPage({ params }: { params: { id: string } }
   const fileTypeLabel = fileType?.label ?? project.fileType;
   const fileTypeDescription = fileType?.description ?? null;
 
+  const processingProgress = await getProcessingProgress(project.id);
+
   return (
     <ProjectPageClient
       project={{
@@ -141,6 +143,7 @@ export default async function ProjectPage({ params }: { params: { id: string } }
       files={files}
       processingRuns={processingRuns}
       processingSummary={processingSummary}
+      processingProgress={processingProgress}
     />
   );
 }

--- a/src/lib/processing-types.ts
+++ b/src/lib/processing-types.ts
@@ -1,0 +1,24 @@
+export type ProcessingRunStatus =
+  | "pending"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "completed_with_errors"
+  | "cancelled";
+
+export type ProcessingProgressSnapshot = {
+  totalFiles: number;
+  completedFiles: number;
+  activeFiles: number;
+};
+
+export type AggregatedFolderNode = {
+  name: string;
+  path: string;
+  type: "folder" | "file";
+  recordCount: number;
+  runId?: string;
+  status?: ProcessingRunStatus;
+  records?: unknown;
+  children?: AggregatedFolderNode[];
+};

--- a/src/lib/project-file-upload.ts
+++ b/src/lib/project-file-upload.ts
@@ -1,0 +1,307 @@
+import path from "path";
+
+import JSZip from "jszip";
+import { generateId } from "better-auth";
+
+import { getDb } from "@/db/client";
+import { validateFileForProjectType } from "@/lib/files";
+import type { FileType } from "@/lib/instruction-sets";
+import { enqueueProcessingRun } from "@/lib/processing-queue";
+import { queueProcessingForFile } from "@/lib/processing-service";
+import { persistProjectFile } from "@/lib/storage";
+
+export class UploadError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "UploadError";
+    this.status = status;
+  }
+}
+
+const ZIP_MIME_TYPES = new Set([
+  "application/zip",
+  "application/x-zip-compressed",
+  "multipart/x-zip",
+  "application/x-zip"
+]);
+
+const MIME_BY_EXTENSION = new Map<string, string>([
+  [".pdf", "application/pdf"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".png", "image/png"],
+  [".gif", "image/gif"],
+  [".bmp", "image/bmp"],
+  [".tif", "image/tiff"],
+  [".tiff", "image/tiff"],
+  [".webp", "image/webp"],
+  [".heic", "image/heic"],
+  [".heif", "image/heif"]
+]);
+
+export type NormalizedProjectFile = {
+  id: string;
+  originalName: string;
+  size: number;
+  contentType: string | null;
+  uploadedViaApi: boolean;
+  createdAt: string;
+};
+
+export type UploadOutcome = {
+  files: NormalizedProjectFile[];
+  processingRunIds: string[];
+  warnings: string[];
+};
+
+type ProjectFileRow = {
+  id: string;
+  originalName: string;
+  size: string | number | bigint;
+  contentType: string | null;
+  uploadedViaApi: boolean;
+  createdAt: Date | string;
+};
+
+type StoreFileParams = {
+  db: any;
+  projectId: string;
+  ownerId: string;
+  file: File;
+  originalName: string;
+  uploadedViaApi: boolean;
+  triggeredBy: string;
+};
+
+type StoreFileResult = {
+  file: NormalizedProjectFile;
+  processingRunId: string | null;
+};
+
+type ArchiveExtractionEntry = {
+  file: File;
+  originalName: string;
+};
+
+type ArchiveExtractionResult = {
+  entries: ArchiveExtractionEntry[];
+  warnings: string[];
+};
+
+function normalizeFileRow(row: ProjectFileRow): NormalizedProjectFile {
+  const rawSize =
+    typeof row.size === "string"
+      ? Number(row.size)
+      : typeof row.size === "bigint"
+        ? Number(row.size)
+        : row.size;
+  const size = Number.isFinite(rawSize) && rawSize >= 0 ? rawSize : 0;
+  const createdAt =
+    row.createdAt instanceof Date ? row.createdAt.toISOString() : new Date(row.createdAt).toISOString();
+
+  return {
+    id: row.id,
+    originalName: row.originalName,
+    size,
+    contentType: row.contentType,
+    uploadedViaApi: row.uploadedViaApi,
+    createdAt
+  };
+}
+
+function isZipArchive(fileName: string | undefined, mimeType: string | null | undefined): boolean {
+  const normalizedMime = (mimeType ?? "").toLowerCase();
+  if (ZIP_MIME_TYPES.has(normalizedMime)) {
+    return true;
+  }
+  const extension = path.extname(fileName ?? "").toLowerCase();
+  return extension === ".zip";
+}
+
+function guessMimeType(filePath: string): string | null {
+  const extension = path.extname(filePath).toLowerCase();
+  return MIME_BY_EXTENSION.get(extension) ?? null;
+}
+
+async function extractArchiveEntries(
+  file: File,
+  projectType: FileType,
+  maxSizeBytes: number
+): Promise<ArchiveExtractionResult> {
+  const warnings: string[] = [];
+  let archive: JSZip;
+  try {
+    archive = await JSZip.loadAsync(await file.arrayBuffer());
+  } catch (error) {
+    throw new UploadError("Unable to read the uploaded ZIP archive.", 400);
+  }
+
+  const entries: ArchiveExtractionEntry[] = [];
+
+  for (const entry of Object.values(archive.files)) {
+    if (!entry || entry.dir) {
+      continue;
+    }
+    const normalizedPath = entry.name.replace(/\\/g, "/").replace(/^\/+/, "");
+    if (!normalizedPath) {
+      continue;
+    }
+
+    const mimeType = guessMimeType(normalizedPath);
+    const validation = validateFileForProjectType(normalizedPath, mimeType, projectType);
+    if (!validation.ok) {
+      warnings.push(`Skipped ${normalizedPath}: ${validation.message}`);
+      continue;
+    }
+
+    const content = await entry.async("uint8array");
+    if (content.byteLength > maxSizeBytes) {
+      const sizeMb = (content.byteLength / (1024 * 1024)).toFixed(2);
+      warnings.push(`Skipped ${normalizedPath}: file exceeds ${sizeMb} MB which is above the limit.`);
+      continue;
+    }
+
+    const buffer = content.slice().buffer;
+    const entryFile = new File([buffer], path.basename(normalizedPath), {
+      type: mimeType ?? "",
+      lastModified: Date.now()
+    });
+
+    entries.push({
+      file: entryFile,
+      originalName: normalizedPath
+    });
+  }
+
+  return { entries, warnings };
+}
+
+async function storeFile({
+  db,
+  projectId,
+  ownerId,
+  file,
+  originalName,
+  uploadedViaApi,
+  triggeredBy
+}: StoreFileParams): Promise<StoreFileResult> {
+  const { relativePath } = await persistProjectFile(projectId, file, path.basename(originalName));
+  const fileId = generateId();
+
+  await db
+    .insertInto("projectFile")
+    .values({
+      id: fileId,
+      projectId,
+      ownerId,
+      originalName,
+      storagePath: relativePath,
+      contentType: file.type || null,
+      size: BigInt(file.size),
+      uploadedViaApi
+    })
+    .executeTakeFirst();
+
+  let processingRunId: string | null = null;
+  try {
+    const run = await queueProcessingForFile({
+      projectId,
+      fileId,
+      triggeredBy
+    });
+    if (run?.runId) {
+      processingRunId = run.runId;
+      enqueueProcessingRun(run.runId);
+    }
+  } catch (error) {
+    console.error("Failed to enqueue processing run", error);
+  }
+
+  const normalized = normalizeFileRow({
+    id: fileId,
+    originalName,
+    size: file.size,
+    contentType: file.type || null,
+    uploadedViaApi,
+    createdAt: new Date()
+  });
+
+  return { file: normalized, processingRunId };
+}
+
+export async function saveProjectUpload(options: {
+  projectId: string;
+  ownerId: string;
+  projectType: FileType;
+  upload: File;
+  uploadedViaApi: boolean;
+  triggeredBy: string;
+  maxFileSizeBytes: number;
+}): Promise<UploadOutcome> {
+  const { projectId, ownerId, projectType, upload, uploadedViaApi, triggeredBy, maxFileSizeBytes } = options;
+  const db = getDb() as any;
+
+  if (isZipArchive(upload.name, upload.type)) {
+    const { entries, warnings } = await extractArchiveEntries(upload, projectType, maxFileSizeBytes);
+
+    if (!entries.length) {
+      const message =
+        warnings.length > 0
+          ? "The archive was processed but no supported files were found."
+          : "The archive did not contain any compatible files for this project.";
+      throw new UploadError(message, 400);
+    }
+
+    const results: StoreFileResult[] = [];
+    for (const entry of entries) {
+      results.push(
+        await storeFile({
+          db,
+          projectId,
+          ownerId,
+          file: entry.file,
+          originalName: entry.originalName,
+          uploadedViaApi,
+          triggeredBy
+        })
+      );
+    }
+
+    return {
+      files: results.map((result) => result.file),
+      processingRunIds: results
+        .map((result) => result.processingRunId)
+        .filter((value): value is string => typeof value === "string" && value.length > 0),
+      warnings
+    };
+  }
+
+  if (upload.size > maxFileSizeBytes) {
+    throw new UploadError("File exceeds size limit", 413);
+  }
+
+  const validation = validateFileForProjectType(upload.name, upload.type, projectType);
+  if (!validation.ok) {
+    throw new UploadError(validation.message, 415);
+  }
+
+  const result = await storeFile({
+    db,
+    projectId,
+    ownerId,
+    file: upload,
+    originalName: upload.name,
+    uploadedViaApi,
+    triggeredBy
+  });
+
+  return {
+    files: [result.file],
+    processingRunIds: result.processingRunId ? [result.processingRunId] : [],
+    warnings: []
+  };
+}
+
+export { normalizeFileRow as normalizeProjectFileRow };


### PR DESCRIPTION
## Summary
- widen the project detail layout and processing runs grid to use more of the screen for results【F:src/app/projects/[id]/ProjectPageClient.tsx†L33-L168】【F:src/app/projects/[id]/ProjectProcessingRunsPanel.tsx†L289-L378】
- add a progress bar, success messaging, and warning handling for file uploads along with a reusable upload service and progress API【F:src/app/projects/[id]/ProjectFilesPanel.tsx†L16-L213】【F:src/lib/project-file-upload.ts†L1-L234】【F:src/app/api/projects/[id]/processing/progress/route.ts†L1-L27】
- support zip archives across web and API uploads and expose aggregated processing results grouped by folder via new endpoints and UI【F:src/app/api/projects/[id]/files/route.ts†L1-L107】【F:src/app/api/projects/[id]/processing/aggregate/route.ts†L1-L27】【F:src/lib/processing-service.ts†L658-L740】【F:src/app/projects/[id]/ProjectProcessingRunsPanel.tsx†L376-L716】

## Testing
- npm run build【3742ee†L1-L28】

------
https://chatgpt.com/codex/tasks/task_e_68caeb0ad9b88323aa8246dd3af6638f